### PR TITLE
Add Garden decompression addon for Castle Week

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "export-data": "node scripts/export-to-notion.js"
   },
   "dependencies": {
+    "2": "^3.0.0",
     "@fullcalendar/core": "^6.1.11",
     "@fullcalendar/daygrid": "^6.1.11",
     "@fullcalendar/interaction": "^6.1.11",

--- a/src/components/BookingSummary.tsx
+++ b/src/components/BookingSummary.tsx
@@ -27,6 +27,7 @@ import { usePricing } from './BookingSummary/BookingSummary.hooks';
 // Import components
 import { StayDetails } from './BookingSummary/components/StayDetails';
 import { AccommodationSection } from './BookingSummary/components/AccommodationSection';
+import { GardenAddonSection } from './BookingSummary/components/GardenAddonSection';
 import { CreditsSection } from './BookingSummary/components/CreditsSection';
 import { ConfirmButtons } from './BookingSummary/components/ConfirmButtons';
 
@@ -39,7 +40,9 @@ export function BookingSummary({
   onClearWeeks,
   onClearAccommodation,
   seasonBreakdown: initialSeasonBreakdown,
-  calculatedWeeklyAccommodationPrice
+  calculatedWeeklyAccommodationPrice,
+  gardenAddon,
+  onClearGardenAddon
 }: BookingSummaryProps) {
   // --- REMOVED: Track component renders (no longer needed) ---
   // Helper function to format dates consistently (needed for the modal)
@@ -354,6 +357,7 @@ export function BookingSummary({
     selectedAccommodation,
     calculatedWeeklyAccommodationPrice,
     foodContribution,
+    gardenAddon,
     appliedDiscount: null
   });
   
@@ -1612,6 +1616,14 @@ Please manually create the booking for this user or process a refund.`;
                 <AccommodationSection 
                   selectedAccommodation={selectedAccommodation}
                   onClearAccommodation={onClearAccommodation}
+                />
+              )}
+
+              {/* Garden Addon Section */}
+              {gardenAddon && (
+                <GardenAddonSection 
+                  gardenAddon={gardenAddon}
+                  onClearGardenAddon={onClearGardenAddon}
                 />
               )}
 

--- a/src/components/BookingSummary/BookingSummary.hooks.ts
+++ b/src/components/BookingSummary/BookingSummary.hooks.ts
@@ -3,20 +3,22 @@ import { calculateTotalNights, calculateTotalWeeksDecimal } from '../../utils/da
 import { calculateBaseFoodCost } from './BookingSummary.utils';
 import type { Week } from '../../types/calendar';
 import type { Accommodation } from '../../types';
-import type { PricingDetails } from './BookingSummary.types';
+import type { PricingDetails, GardenAddon } from './BookingSummary.types';
 
 interface UsePricingProps {
   selectedWeeks: Week[];
   selectedAccommodation: Accommodation | null;
   calculatedWeeklyAccommodationPrice: number | null;
   foodContribution: number | null;
+  gardenAddon?: GardenAddon | null;
 }
 
 export function usePricing({
   selectedWeeks,
   selectedAccommodation,
   calculatedWeeklyAccommodationPrice,
-  foodContribution
+  foodContribution,
+  gardenAddon
 }: UsePricingProps): PricingDetails {
   return useMemo((): PricingDetails => {
     console.log('[BookingSummary] --- Recalculating Pricing (useMemo) ---');
@@ -44,9 +46,10 @@ export function usePricing({
     const foodDiscountAmount = 0;
     const effectiveWeeklyRate = 0;
     
-    // 4. Subtotal is just accommodation cost
-    const subtotal = totalAccommodationCost;
-    console.log('[BookingSummary] useMemo: Calculated Subtotal:', { totalAccommodationCost, finalFoodCost, subtotal });
+    // 4. Subtotal is accommodation cost + garden addon
+    const gardenAddonCost = gardenAddon?.price || 0;
+    const subtotal = totalAccommodationCost + gardenAddonCost;
+    console.log('[BookingSummary] useMemo: Calculated Subtotal:', { totalAccommodationCost, gardenAddonCost, finalFoodCost, subtotal });
 
     // No discount codes - simplified pricing
     let finalTotalAmount = subtotal;
@@ -70,6 +73,7 @@ export function usePricing({
       totalNights,
       totalAccommodationCost,
       totalFoodAndFacilitiesCost: finalFoodCost,
+      gardenAddonCost,
       subtotal,
       totalAmount: finalTotalAmount,
       appliedCodeDiscountValue: discountCodeAmount,

--- a/src/components/BookingSummary/BookingSummary.types.ts
+++ b/src/components/BookingSummary/BookingSummary.types.ts
@@ -11,6 +11,15 @@ export interface SeasonBreakdown {
   }>;
 }
 
+export interface GardenAddon {
+  id: string;
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  price: number;
+  description: string;
+}
+
 export interface BookingSummaryProps {
   selectedWeeks: Week[];
   selectedAccommodation: Accommodation | null;
@@ -18,6 +27,8 @@ export interface BookingSummaryProps {
   onClearAccommodation: () => void;
   seasonBreakdown?: SeasonBreakdown; // Optional for backward compatibility
   calculatedWeeklyAccommodationPrice: number | null;
+  gardenAddon?: GardenAddon | null;
+  onClearGardenAddon?: () => void;
 }
 
 // Helper function to calculate pricing details
@@ -28,6 +39,7 @@ export interface PricingDetails {
   effectiveBaseRate: number;
   totalAccommodationCost: number;
   totalFoodAndFacilitiesCost: number;
+  gardenAddonCost?: number;
   subtotal: number;
   durationDiscountAmount: number; // Always 0 now
   durationDiscountPercent: number; // Always 0 now

--- a/src/components/BookingSummary/components/GardenAddonSection.tsx
+++ b/src/components/BookingSummary/components/GardenAddonSection.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { X, MapPin, Calendar } from 'lucide-react';
+import { format } from 'date-fns';
+import { formatPriceDisplay } from '../BookingSummary.utils';
+import type { GardenAddon } from '../BookingSummary.types';
+
+interface GardenAddonSectionProps {
+  gardenAddon: GardenAddon;
+  onClearGardenAddon?: () => void;
+}
+
+export function GardenAddonSection({ gardenAddon, onClearGardenAddon }: GardenAddonSectionProps) {
+  const formatDateRange = (start: Date, end: Date) => {
+    const startMonth = format(start, 'MMM');
+    const endMonth = format(end, 'MMM');
+    const startDay = format(start, 'd');
+    const endDay = format(end, 'd');
+    
+    if (startMonth === endMonth) {
+      return `${startMonth} ${startDay}-${endDay}`;
+    }
+    return `${startMonth} ${startDay} - ${endMonth} ${endDay}`;
+  };
+
+  return (
+    <div className="mt-6 p-4 bg-surface/50 rounded-sm border border-accent-primary/30">
+      <div className="flex justify-between items-start mb-3">
+        <div className="flex items-center gap-2">
+          <MapPin className="w-5 h-5 text-accent-primary" />
+          <h3 className="font-display text-lg text-primary">Garden Decompression</h3>
+        </div>
+        {onClearGardenAddon && (
+          <button
+            onClick={onClearGardenAddon}
+            className="text-secondary hover:text-primary transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+      
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-sm text-secondary">
+          <Calendar className="w-4 h-4" />
+          <span className="font-mono">{formatDateRange(gardenAddon.startDate, gardenAddon.endDate)}</span>
+        </div>
+        
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-secondary font-mono">{gardenAddon.name}</span>
+          <span className="font-display text-lg text-primary">
+            {formatPriceDisplay(gardenAddon.price)}
+          </span>
+        </div>
+        
+        <div className="mt-3 pt-3 border-t border-border">
+          <p className="text-xs text-secondary font-mono italic">
+            Includes accommodation at The Garden in Portugal
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/GardenDecompressionAddon.tsx
+++ b/src/components/GardenDecompressionAddon.tsx
@@ -1,0 +1,230 @@
+import React, { useState, useMemo } from 'react';
+import { MapPin, Calendar, Plane, Info } from 'lucide-react';
+import { format, addDays } from 'date-fns';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface GardenDecompressionOption {
+  id: string;
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  price: number;
+  description: string;
+}
+
+interface GardenDecompressionAddonProps {
+  castleEndDate: Date; // September 26, 2025
+  onSelectAddon: (option: GardenDecompressionOption | null) => void;
+  selectedAddon: GardenDecompressionOption | null;
+}
+
+export function GardenDecompressionAddon({ 
+  castleEndDate, 
+  onSelectAddon,
+  selectedAddon 
+}: GardenDecompressionAddonProps) {
+  const [showTravelInfo, setShowTravelInfo] = useState(false);
+
+  // Define the decompression options
+  const decompressionOptions: GardenDecompressionOption[] = useMemo(() => {
+    const sept26 = castleEndDate;
+    const sept29 = addDays(sept26, 3);
+    const sept30 = addDays(sept26, 4);
+    const oct6 = addDays(sept26, 10);
+
+    return [
+      {
+        id: 'weekend',
+        name: 'Weekend Decompression',
+        startDate: sept26,
+        endDate: sept29,
+        price: 125,
+        description: 'Fri-Mon • 3 nights of gentle re-entry'
+      },
+      {
+        id: 'full-week',
+        name: 'Full Week Decompression',
+        startDate: sept26,
+        endDate: oct6,
+        price: 400,
+        description: 'Fri-Sun • 10 nights of deep integration'
+      },
+      {
+        id: 'october-week',
+        name: 'October Week',
+        startDate: sept30,
+        endDate: oct6,
+        price: 275,
+        description: 'Mon-Sun • 7 nights starting after the weekend'
+      }
+    ];
+  }, [castleEndDate]);
+
+  const formatDateRange = (start: Date, end: Date) => {
+    const startMonth = format(start, 'MMM');
+    const endMonth = format(end, 'MMM');
+    const startDay = format(start, 'd');
+    const endDay = format(end, 'd');
+    
+    if (startMonth === endMonth) {
+      return `${startMonth} ${startDay}-${endDay}`;
+    }
+    return `${startMonth} ${startDay} - ${endMonth} ${endDay}`;
+  };
+
+  return (
+    <div className="rounded-sm shadow-sm py-3 xs:py-4 sm:py-6 mb-4 xs:mb-5 sm:mb-6">
+      <div className="flex flex-col gap-3 mb-4">
+        <h2 className="text-2xl sm:text-3xl font-display font-light text-primary">
+          Continue to The Garden? (Optional)
+        </h2>
+        <p className="text-sm sm:text-base text-secondary font-mono">
+          Decompress after Castle Week at our sister location in Portugal
+        </p>
+      </div>
+
+      {/* Options Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
+        {decompressionOptions.map((option) => {
+          const isSelected = selectedAddon?.id === option.id;
+          
+          return (
+            <motion.button
+              key={option.id}
+              onClick={() => onSelectAddon(isSelected ? null : option)}
+              className={`
+                relative p-4 rounded-sm border-2 transition-all duration-200
+                ${isSelected 
+                  ? 'border-accent-primary bg-accent-primary/10' 
+                  : 'border-border hover:border-accent-primary/50 bg-surface/50'
+                }
+              `}
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              {/* Selected indicator */}
+              {isSelected && (
+                <div className="absolute top-2 right-2">
+                  <div className="w-6 h-6 rounded-full bg-accent-primary flex items-center justify-center">
+                    <svg className="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  </div>
+                </div>
+              )}
+
+              <div className="text-left">
+                <h3 className="font-display text-lg text-primary mb-1">
+                  {option.name}
+                </h3>
+                <p className="text-xs text-secondary mb-2 font-mono">
+                  {option.description}
+                </p>
+                <div className="flex items-center gap-2 text-sm text-secondary mb-2">
+                  <Calendar className="w-4 h-4" />
+                  <span>{formatDateRange(option.startDate, option.endDate)}</span>
+                </div>
+                <div className="text-xl font-display text-primary">
+                  €{option.price}
+                </div>
+              </div>
+            </motion.button>
+          );
+        })}
+      </div>
+
+      {/* Travel Information */}
+      <div className="border-t border-border pt-4">
+        <button
+          onClick={() => setShowTravelInfo(!showTravelInfo)}
+          className="flex items-center gap-2 text-sm text-secondary hover:text-primary transition-colors font-mono"
+        >
+          <Info className="w-4 h-4" />
+          <span>Travel Information</span>
+          <svg
+            className={`w-4 h-4 transition-transform ${showTravelInfo ? 'rotate-180' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        <AnimatePresence>
+          {showTravelInfo && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              className="overflow-hidden"
+            >
+              <div className="mt-4 p-4 bg-surface/50 rounded-sm space-y-3">
+                <div className="flex items-start gap-3">
+                  <MapPin className="w-5 h-5 text-accent-primary mt-0.5 flex-shrink-0" />
+                  <div>
+                    <h4 className="font-display text-primary mb-1">Location</h4>
+                    <p className="text-sm text-secondary font-mono">
+                      The Garden is located in Northern Portugal, 45 minutes from Porto
+                    </p>
+                    <a 
+                      href="https://thegarden.pt" 
+                      target="_blank" 
+                      rel="noopener noreferrer"
+                      className="text-sm text-accent-primary hover:underline font-mono mt-1 inline-block"
+                    >
+                      Visit The Garden website →
+                    </a>
+                  </div>
+                </div>
+
+                <div className="flex items-start gap-3">
+                  <Plane className="w-5 h-5 text-accent-primary mt-0.5 flex-shrink-0" />
+                  <div>
+                    <h4 className="font-display text-primary mb-1">How to Get There</h4>
+                    <ol className="text-sm text-secondary font-mono space-y-1">
+                      <li>1. Uber from the Castle to Paris Orly Airport (ORY)</li>
+                      <li>2. Fly 2 hours to Porto Airport (OPO)</li>
+                      <li>3. Uber 45 minutes to The Garden</li>
+                      <li className="text-accent-primary">→ Rideshares will be organized in the community</li>
+                    </ol>
+                  </div>
+                </div>
+
+                <div className="text-xs text-secondary font-mono italic">
+                  Note: The Garden decompression is a separate booking from Castle Week. 
+                  You'll receive separate confirmation and check-in instructions.
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* Selected addon summary */}
+      {selectedAddon && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mt-4 p-3 bg-accent-primary/10 rounded-sm border border-accent-primary/30"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className="w-2 h-2 rounded-full bg-accent-primary animate-pulse" />
+              <span className="text-sm font-mono text-primary">
+                Garden Decompression Added: {selectedAddon.name}
+              </span>
+            </div>
+            <button
+              onClick={() => onSelectAddon(null)}
+              className="text-xs text-secondary hover:text-primary font-mono"
+            >
+              Remove
+            </button>
+          </div>
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Book2Page.tsx
+++ b/src/pages/Book2Page.tsx
@@ -30,6 +30,7 @@ import { InfoBox } from '../components/InfoBox';
 import { useUserPermissions } from '../hooks/useUserPermissions';
 import { Fireflies } from '../components/Fireflies';
 import { FireflyPortal } from '../components/FireflyPortal';
+import { GardenDecompressionAddon } from '../components/GardenDecompressionAddon';
 
 // Define SeasonBreakdown type locally
 interface SeasonBreakdown {
@@ -108,6 +109,7 @@ export function Book2Page() {
   const [selectedWeekForCustomization, setSelectedWeekForCustomization] = useState<Week | null>(null);
   const [lastRefresh, setLastRefresh] = useState(0);
   const [showDiscountModal, setShowDiscountModal] = useState(false);
+  const [selectedGardenAddon, setSelectedGardenAddon] = useState<any>(null);
 
 
 
@@ -931,6 +933,13 @@ export function Book2Page() {
                 )}
               </div> {/* Closing Calendar card div */}
               
+              {/* Garden Decompression Addon */}
+              <GardenDecompressionAddon
+                castleEndDate={new Date('2025-09-26T00:00:00Z')}
+                onSelectAddon={setSelectedGardenAddon}
+                selectedAddon={selectedGardenAddon}
+              />
+              
               {/* Outer Cabin Selector keeps py-* padding */}
               <div className="rounded-sm shadow-sm py-3 xs:py-4 sm:py-6 mb-4 xs:mb-5 sm:mb-6 cabin-selector">
                 {/* REMOVING px-* padding from this h2 */}
@@ -964,6 +973,8 @@ export function Book2Page() {
                     onClearAccommodation={() => setSelectedAccommodation(null)}
                     seasonBreakdown={seasonBreakdown}
                     calculatedWeeklyAccommodationPrice={selectedAccommodation ? weeklyAccommodationInfo[selectedAccommodation]?.price ?? null : null}
+                    gardenAddon={selectedGardenAddon}
+                    onClearGardenAddon={() => setSelectedGardenAddon(null)}
                   />
                 ) : (
                   <div className="text-secondary text-sm xs:text-sm font-mono">


### PR DESCRIPTION
## Summary
- Added optional Garden decompression stays after Castle Week at The Garden in Portugal
- Implemented three flexible booking options with clear pricing
- Integrated travel information and directions

## Features
### 🌿 Garden Decompression Options
- **Weekend Decompression** (Sep 26-29): €125 for 3 nights of gentle re-entry
- **Full Week Decompression** (Sep 26-Oct 6): €400 for 10 nights of deep integration
- **October Week** (Sep 30-Oct 6): €275 for 7 nights starting after the weekend

### ✈️ Travel Information
- Clear directions from Castle to The Garden in Portugal
- Uber → Paris Orly → Fly to Porto → Uber to Garden
- Link to The Garden website
- Note about rideshare coordination

### 💳 Booking Integration
- Seamless integration with existing Castle Week booking flow
- Automatic pricing updates including VAT (24%)
- Visual selection indicators and easy removal option
- Garden addon appears in booking summary with clear pricing

## UI/UX Improvements
- Clean card-based selection interface
- Expandable travel information to reduce clutter
- Visual feedback on selection (checkmarks, color changes)
- Mobile-responsive design

## Test Plan
- [x] Build passes without errors
- [ ] Test selecting different Garden addon options
- [ ] Verify pricing calculations with VAT
- [ ] Test addon removal functionality
- [ ] Check mobile responsiveness
- [ ] Verify booking flow completion with addon

🤖 Generated with [Claude Code](https://claude.ai/code)