### PR TITLE
Fix bathroom filter and update UI text

### DIFF
--- a/src/components/GardenDecompressionAddon.tsx
+++ b/src/components/GardenDecompressionAddon.tsx
@@ -43,7 +43,7 @@ export function GardenDecompressionAddon({
       },
       {
         id: 'full-week',
-        name: 'Full Week Decompression',
+        name: 'Full Decompression',
         startDate: sept26,
         endDate: oct6,
         price: 400,

--- a/src/components/GardenDecompressionAddon.tsx
+++ b/src/components/GardenDecompressionAddon.tsx
@@ -84,7 +84,7 @@ export function GardenDecompressionAddon({
           </span>
         </div>
         <p className="text-sm sm:text-base text-secondary font-mono">
-          Decompress after The Castle at our permanent campus in Portugal
+          Since the prior Castle in 2019, we've built a permanent campus. As you've passed curation, you're invited to decompress with the crew.
         </p>
         <p className="text-xs text-secondary font-mono">
           You can proceed without selecting any decompression option.

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -57,7 +57,7 @@ export function isWeekStatus(status: string): status is WeekStatus {
 
 // Helper to check if a week is an event week (doesn't require accommodation)
 export function isEventWeek(week: Week): boolean {
-    const eventWeekNames = ['Weekend', 'Full Week', 'October Week', 'Decompression', 'Weekend Decompression', 'Full Week Decompression'];
+    const eventWeekNames = ['Weekend', 'Full Week', 'October Week', 'Decompression', 'Weekend Decompression', 'Full Decompression'];
     return week.isEventWeek === true || (week.name ? eventWeekNames.some(eventName => week.name!.includes(eventName)) : false);
 }
 


### PR DESCRIPTION
## Summary
- Fixed bathroom filter logic to use word boundaries (prevents false matches)
- Combined "Your Own Tent" and "Your Own Van" into a single card with stacked buttons
- Updated decompression description to be more personal
- Changed "Full Week Decompression" to "Full Decompression"

## Changes
1. **Bathroom Filter Fix**: Now correctly identifies "bath" as private and "shared bath" as shared
2. **Tent/Van UI**: Combined into one card with two buttons, matching other card dimensions
3. **Text Updates**: More personal decompression invitation mentioning the permanent campus

🤖 Generated with [Claude Code](https://claude.ai/code)