### PR TITLE
Fix NaN pricing, add Castle View Bell Tent, and UI improvements

### DIFF
--- a/src/components/BookingSummary/BookingSummary.hooks.ts
+++ b/src/components/BookingSummary/BookingSummary.hooks.ts
@@ -29,7 +29,12 @@ export function usePricing({
     const displayWeeks = selectedWeeks.length > 0 ? Math.round(exactWeeksDecimal * 10) / 10 : 0;
     
     // === Calculate Accommodation Cost using discounted weekly price ===
-    const weeklyAccPrice = calculatedWeeklyAccommodationPrice ?? 0;
+    // Ensure we have a valid number, default to 0 if null/undefined/NaN
+    const weeklyAccPrice = (calculatedWeeklyAccommodationPrice !== null && 
+                           calculatedWeeklyAccommodationPrice !== undefined && 
+                           !isNaN(calculatedWeeklyAccommodationPrice)) 
+                          ? calculatedWeeklyAccommodationPrice 
+                          : 0;
     const totalAccommodationCost = parseFloat((weeklyAccPrice * displayWeeks).toFixed(2));
 
     // === Calculate Food & Facilities Cost ===

--- a/supabase/migrations/20250829075331_add_castle_view_bell_tent_update_inventories.sql
+++ b/supabase/migrations/20250829075331_add_castle_view_bell_tent_update_inventories.sql
@@ -1,0 +1,80 @@
+-- Add new 4M Bell Tent, Castle View accommodation
+INSERT INTO accommodations (
+  title,
+  location,
+  price,
+  rating,
+  reviews,
+  image_url,
+  type,
+  capacity,
+  available,
+  is_fungible,
+  inventory,
+  bathroom_type,
+  description,
+  additional_info,
+  display_order
+) VALUES (
+  '4M Bell Tent, Castle View',
+  'The Garden',
+  1000, -- €1000 price
+  5.0,
+  0,
+  'https://storage.tally.so/f385d036-6b48-4a0b-b119-2e334c0bc1f0/photo_2023-09-07_18-55-18.jpg', -- Using same image as regular bell tent
+  'Bell Tent',
+  2,
+  0,
+  true, -- fungible
+  3, -- Only 3 available
+  'shared',
+  '4-meter bell tent with panoramic castle views',
+  'Premium location • Shared bath facilities • Fits 2 people',
+  5 -- Display after other bell tents
+) ON CONFLICT (title) DO UPDATE SET
+  price = EXCLUDED.price,
+  inventory = EXCLUDED.inventory,
+  description = EXCLUDED.description,
+  additional_info = EXCLUDED.additional_info;
+
+-- Update inventory for regular 4M Bell Tents to 35
+UPDATE accommodations 
+SET inventory = 35
+WHERE (title = '4 Meter Bell Tent' OR title = '4m Bell Tent')
+  AND type = 'Bell Tent';
+
+-- Update inventory for Tipis to 20
+UPDATE accommodations 
+SET inventory = 20
+WHERE (title = 'Single Tipi' OR title LIKE '%Tipi%')
+  AND type = 'Tipi';
+
+-- Create accommodation items for the new Castle View Bell Tent
+DO $$
+DECLARE
+  acc_id UUID;
+  item_count INT;
+BEGIN
+  -- Get the accommodation ID
+  SELECT id INTO acc_id 
+  FROM accommodations 
+  WHERE title = '4M Bell Tent, Castle View'
+  LIMIT 1;
+  
+  IF acc_id IS NOT NULL THEN
+    -- Check if items already exist
+    SELECT COUNT(*) INTO item_count
+    FROM accommodation_items
+    WHERE accommodation_id = acc_id;
+    
+    -- Only create if they don't exist
+    IF item_count = 0 THEN
+      -- Create 3 accommodation items for the Castle View Bell Tent
+      INSERT INTO accommodation_items (accommodation_id, item_number, display_name)
+      VALUES 
+        (acc_id, 1, '4M Bell Tent Castle View #1'),
+        (acc_id, 2, '4M Bell Tent Castle View #2'),
+        (acc_id, 3, '4M Bell Tent Castle View #3');
+    END IF;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Fixed NaN total issue in booking summary
- Added new "4M Bell Tent, Castle View" accommodation
- Updated inventory counts for Bell Tents and Tipis
- Fixed bathroom filter logic with proper word boundaries
- Combined tent/van cards into single UI element
- Updated decompression text

## Changes

### 🐛 Bug Fixes
- **NaN pricing fix**: Added proper null/undefined/NaN handling in pricing calculations
- **Bathroom filter**: Fixed word boundary detection (prevents "sabbath" matching "bath")

### ✨ New Features
- **4M Bell Tent, Castle View**: New premium accommodation at €1000 with 3 units available
- **Inventory updates**: 
  - Regular Bell Tents: 35 units
  - Tipis: 20 units

### 💄 UI Improvements
- Combined "Your Own Tent" and "Your Own Van" into single card with stacked buttons
- Changed "Full Week Decompression" to "Full Decompression"
- Updated decompression description with more personal invitation
- Added BTC & ETH payment option display

## Database Migration Required
Run the included migration to:
- Add the new Castle View Bell Tent accommodation
- Update inventory counts for existing accommodations

🤖 Generated with [Claude Code](https://claude.ai/code)