### PR TITLE
Add sold out feature for accommodations

### DIFF
--- a/src/components/CabinSelector.tsx
+++ b/src/components/CabinSelector.tsx
@@ -35,6 +35,7 @@ interface ExtendedAccommodation extends Accommodation {
   property_location?: string | null;
   property_section?: string | null;
   additional_info?: string | null;
+  sold_out?: boolean;
 }
 
 interface Props {
@@ -625,6 +626,7 @@ export function CabinSelector({
                       {tentAcc && (
                         <button
                           onClick={() => {
+                            if (tentAcc.sold_out) return;
                             if (testMode || (selectedWeeks.length > 0 && !isDisabled)) {
                               handleSelectAccommodation(tentAcc.id);
                             }
@@ -632,11 +634,15 @@ export function CabinSelector({
                           className={clsx(
                             "flex-1 p-4 border-b border-border transition-all duration-200 hover:bg-surface-hover flex flex-col justify-center items-center min-h-[150px]",
                             selectedAccommodationId === tentAcc.id && "bg-[color-mix(in_srgb,_var(--color-bg-surface)_95%,_var(--color-accent-primary)_5%)] shadow-lg",
-                            (!testMode && (!selectedWeeks.length || isDisabled)) && "opacity-50 cursor-not-allowed"
+                            (tentAcc.sold_out || (!testMode && (!selectedWeeks.length || isDisabled))) && "opacity-50 cursor-not-allowed"
                           )}
                         >
                           <h3 className="text-lg font-medium text-primary font-lettra-bold uppercase mb-2">YOUR OWN TENT</h3>
-                          <span className="text-accent-primary text-xl font-lettra-bold font-mono">Free</span>
+                          {tentAcc.sold_out ? (
+                            <span className="text-orange-600 text-xl font-bold font-mono">SOLD OUT</span>
+                          ) : (
+                            <span className="text-accent-primary text-xl font-lettra-bold font-mono">Free</span>
+                          )}
                         </button>
                       )}
                       
@@ -644,6 +650,7 @@ export function CabinSelector({
                       {vanAcc && (
                         <button
                           onClick={() => {
+                            if (vanAcc.sold_out) return;
                             if (testMode || (selectedWeeks.length > 0 && !isDisabled)) {
                               handleSelectAccommodation(vanAcc.id);
                             }
@@ -651,11 +658,15 @@ export function CabinSelector({
                           className={clsx(
                             "flex-1 p-4 transition-all duration-200 hover:bg-surface-hover flex flex-col justify-center items-center min-h-[150px]",
                             selectedAccommodationId === vanAcc.id && "bg-[color-mix(in_srgb,_var(--color-bg-surface)_95%,_var(--color-accent-primary)_5%)] shadow-lg",
-                            (!testMode && (!selectedWeeks.length || isDisabled)) && "opacity-50 cursor-not-allowed"
+                            (vanAcc.sold_out || (!testMode && (!selectedWeeks.length || isDisabled))) && "opacity-50 cursor-not-allowed"
                           )}
                         >
                           <h3 className="text-lg font-medium text-primary font-lettra-bold uppercase mb-2">YOUR OWN VAN</h3>
-                          <span className="text-accent-primary text-xl font-lettra-bold font-mono">Free</span>
+                          {vanAcc.sold_out ? (
+                            <span className="text-orange-600 text-xl font-bold font-mono">SOLD OUT</span>
+                          ) : (
+                            <span className="text-accent-primary text-xl font-lettra-bold font-mono">Free</span>
+                          )}
                         </button>
                       )}
                     </div>
@@ -732,8 +743,10 @@ export function CabinSelector({
                     isSelected 
                       ? "shadow-lg bg-[color-mix(in_srgb,_var(--color-bg-surface)_95%,_var(--color-accent-primary)_5%)]" 
                       : "bg-surface", // Use the renamed class
+                    // Sold out state
+                    acc.sold_out && "opacity-60",
                     // Pointer state:
-                    (testMode || (finalCanSelect && !isDisabled)) && 'cursor-pointer'
+                    (testMode || (finalCanSelect && !isDisabled)) && !acc.sold_out && 'cursor-pointer'
                   )}
                   onClick={(e) => {
                     // Check if click is on interactive elements that should not trigger selection
@@ -741,6 +754,11 @@ export function CabinSelector({
                     
                     // Don't select if clicking on buttons, links, or other interactive elements
                     if (target.closest('button') || target.closest('a')) {
+                      return;
+                    }
+                    
+                    // Don't allow selection if sold out
+                    if (acc.sold_out) {
                       return;
                     }
                     
@@ -754,14 +772,17 @@ export function CabinSelector({
                   }} 
                 >
                   {/* Use the StatusOverlay helper component */}
-                  <StatusOverlay isVisible={!testMode && isDisabled} zIndex={4}>
+                  <StatusOverlay isVisible={acc.sold_out} zIndex={5}>
+                    <span className="text-orange-600 font-bold">SOLD OUT</span>
+                  </StatusOverlay>
+                  <StatusOverlay isVisible={!testMode && isDisabled && !acc.sold_out} zIndex={4}>
                     Select dates first
                   </StatusOverlay>
-                  <StatusOverlay isVisible={!testMode && !isDisabled && isFullyBooked} zIndex={3}>
+                  <StatusOverlay isVisible={!testMode && !isDisabled && isFullyBooked && !acc.sold_out} zIndex={3}>
                     {pendingBookings[acc.id] && pendingBookings[acc.id].count > 0 ? 'Being booked' : 'Booked out'}
                   </StatusOverlay>
                   <StatusOverlay 
-                    isVisible={!testMode && !isDisabled && isOutOfSeason && !isFullyBooked} 
+                    isVisible={!testMode && !isDisabled && isOutOfSeason && !isFullyBooked && !acc.sold_out} 
                     zIndex={2}
                     className="border-amber-500 dark:border-amber-600" // Pass specific class for amber border
                   >

--- a/src/components/admin/Accommodations.tsx
+++ b/src/components/admin/Accommodations.tsx
@@ -23,6 +23,7 @@ interface Accommodation {
   has_wifi: boolean;
   has_electricity: boolean;
   is_unlimited: boolean;
+  sold_out?: boolean;
   additional_info: string;
   property_location: string | null; // Main property location
   property_section: string | null; // Sub-section (e.g., floor for Renaissance)
@@ -281,6 +282,7 @@ export function Accommodations() {
       capacity: 1, // Add default capacity
       has_wifi: false,
       has_electricity: false,
+      sold_out: false,
       additional_info: '',
       property_location: null,
       property_section: null
@@ -637,6 +639,11 @@ export function Accommodations() {
     // has_electricity (boolean)
     if (!originalAccommodation || currentEditData.has_electricity !== originalAccommodation.has_electricity) {
         dataToSave.has_electricity = currentEditData.has_electricity;
+    }
+
+    // sold_out (boolean)
+    if (!originalAccommodation || currentEditData.sold_out !== originalAccommodation.sold_out) {
+        dataToSave.sold_out = currentEditData.sold_out;
     }
 
     // property_location (enum string or null)
@@ -1375,6 +1382,16 @@ export function Accommodations() {
                     />
                     <span>Has Electricity</span>
                   </label>
+                  <label className={`${checkboxLabelClassName} text-orange-500`}>
+                    <input 
+                      type="checkbox" 
+                      checked={!!newAccommodationData.sold_out} 
+                      onChange={(e) => handleNewAccommodationInputChange(e, 'sold_out')} 
+                      disabled={createLoading} 
+                      className={checkboxInputClassName}
+                    />
+                    <span className="font-semibold">Sold Out</span>
+                  </label>
                 </div>
               </div>
             )}
@@ -1727,6 +1744,10 @@ export function Accommodations() {
                             <input type="checkbox" checked={!!currentEditData.has_electricity} onChange={(e) => handleInputChange(e, 'has_electricity')} disabled={editLoading} className={checkboxInputClassName}/>
                             <span>Has Electricity</span>
                          </label>
+                         <label className={`${checkboxLabelClassName} text-orange-500`}>
+                            <input type="checkbox" checked={!!currentEditData.sold_out} onChange={(e) => handleInputChange(e, 'sold_out')} disabled={editLoading} className={checkboxInputClassName}/>
+                            <span className="font-semibold">Sold Out</span>
+                         </label>
                     </div>
                   </>
                 ) : (
@@ -1777,10 +1798,11 @@ export function Accommodations() {
                         <span className='text-xs ml-1'>({ALLOWED_PROPERTY_SECTIONS.find(sec => sec.value === accommodation.property_section)?.label})</span>
                       )}
                     </p>
-                    <div className="flex gap-2 pt-1"> 
+                    <div className="flex gap-2 pt-1 flex-wrap"> 
                       {accommodation.has_wifi && <span className="inline-flex items-center gap-1 bg-[var(--color-bg-success-subtle)] text-[var(--color-text-success)] px-2 py-0.5 rounded-sm text-xs"><Wifi size={12}/> WiFi</span>}
                       {accommodation.has_electricity && <span className="inline-flex items-center gap-1 bg-[var(--color-bg-success-subtle)] text-[var(--color-text-success)] px-2 py-0.5 rounded-sm text-xs"><Zap size={12}/> Electricity</span>}
-                      {!accommodation.has_wifi && !accommodation.has_electricity && <span className='text-xs italic'>No listed features.</span>}
+                      {accommodation.sold_out && <span className="inline-flex items-center gap-1 bg-orange-100 text-orange-700 px-2 py-0.5 rounded-sm text-xs font-semibold">SOLD OUT</span>}
+                      {!accommodation.has_wifi && !accommodation.has_electricity && !accommodation.sold_out && <span className='text-xs italic'>No listed features.</span>}
                     </div>
                   </>
                 )}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,7 @@ export interface Accommodation {
   bathroom_type?: 'none' | 'private' | 'shared';
   has_wifi: boolean;
   has_electricity: boolean;
+  sold_out?: boolean;
   bed_size: string | null;
   image_url: string | null;
   is_fungible: boolean;

--- a/supabase/migrations/20250829_add_sold_out_field_to_accommodations.sql
+++ b/supabase/migrations/20250829_add_sold_out_field_to_accommodations.sql
@@ -1,0 +1,6 @@
+-- Add sold_out field to accommodations table
+ALTER TABLE accommodations 
+ADD COLUMN IF NOT EXISTS sold_out BOOLEAN DEFAULT FALSE;
+
+-- Add comment for documentation
+COMMENT ON COLUMN accommodations.sold_out IS 'Indicates if the accommodation is sold out and should not be available for booking';


### PR DESCRIPTION
## Summary
- Add sold_out boolean field to accommodations table via migration
- Update admin panel with sold out toggle checkbox (orange styling for visibility)
- Display "SOLD OUT" overlay on accommodation cards when marked as sold out
- Prevent selection of sold out accommodations in booking flow
- Apply opacity styling to sold out cards for better UX

## Test plan
- [ ] Test admin panel sold out toggle functionality
- [ ] Verify sold out overlay displays correctly on accommodation cards
- [ ] Confirm sold out accommodations cannot be selected
- [ ] Test visual styling (opacity, orange text) works as expected
- [ ] Run database migration to add sold_out field

🤖 Generated with [Claude Code](https://claude.ai/code)