### PR TITLE
Fix bathroom filter for shared bath descriptions

### DIFF
--- a/src/components/CabinSelector.tsx
+++ b/src/components/CabinSelector.tsx
@@ -358,8 +358,9 @@ export function CabinSelector({
       return 'private';
     }
     
-    // If just mentions 'bath' or 'bathroom' as a whole word (not part of another word), assume private
-    if (/\bbath(room)?\b/i.test(desc)) {
+    // Check if mentions 'bath' or 'bathroom' WITHOUT being preceded by 'shared'
+    // This catches cases like "bath" or "bathroom" that are private
+    if (/\bbath(room)?\b/i.test(desc) && !/\bshared\s+(bath|bathroom)/i.test(desc)) {
       return 'private';
     }
     


### PR DESCRIPTION
## Summary
• Fixed bathroom filter logic to correctly distinguish private vs shared bathrooms
• 'bath' without 'shared' qualifier now properly categorizes as private bathroom  
• 'shared bath' descriptions now correctly categorize as shared bathroom

## Test plan
- [ ] Test Private Bathrooms filter shows only accommodations with private bathrooms
- [ ] Test Shared Bathrooms filter shows only accommodations with shared bathrooms  
- [ ] Verify accommodations with "shared bath" descriptions appear in shared filter
- [ ] Verify accommodations with just "bath" descriptions appear in private filter

🤖 Generated with [Claude Code](https://claude.ai/code)