### PR TITLE
Fix bathroom filter: shared bath=shared, private bath=private, bath=private, no mention=shared

### DIFF
--- a/src/components/CabinSelector.tsx
+++ b/src/components/CabinSelector.tsx
@@ -339,28 +339,21 @@ export function CabinSelector({
       return accommodation.bathroom_type;
     }
     
-    // Check description for specific bathroom indicators
-    const desc = accommodation.description || '';
+    // Check description and additional_info for bathroom indicators
+    const desc = (accommodation.description || '') + ' ' + (accommodation.additional_info || '');
+    const lowerDesc = desc.toLowerCase();
     
-    // Check for shared bathroom indicators first (more specific)
-    // Using regex with word boundaries to avoid false matches
-    if (/\bshared\s+(bath|bathroom)/i.test(desc) || 
-        /\bshared\s+facilities/i.test(desc) || 
-        /\bcommunal\s+(bath|bathroom)/i.test(desc)) {
+    // Simple rule: if it contains just 'bath' (not preceded by other words like 'shared'), it's private
+    // If it contains 'shared bath', 'communal bath', etc., it's shared
+    if (lowerDesc.includes('shared bath') || 
+        lowerDesc.includes('communal bath') || 
+        lowerDesc.includes('shared facilities') ||
+        lowerDesc.includes('shared bathroom')) {
       return 'shared';
     }
     
-    // Check for private bathroom indicators
-    if (/\bprivate\s+(bath|bathroom)/i.test(desc) || 
-        /\bensuite\b/i.test(desc) || 
-        /\ben-suite\b/i.test(desc) || 
-        /\bown\s+(bath|bathroom)/i.test(desc)) {
-      return 'private';
-    }
-    
-    // Check if mentions 'bath' or 'bathroom' WITHOUT being preceded by 'shared'
-    // This catches cases like "bath" or "bathroom" that are private
-    if (/\bbath(room)?\b/i.test(desc) && !/\bshared\s+(bath|bathroom)/i.test(desc)) {
+    // If it just mentions 'bath' or 'bathroom' (including 'private bath'), it's private
+    if (lowerDesc.includes('bath')) {
       return 'private';
     }
     

--- a/src/components/CabinSelector.tsx
+++ b/src/components/CabinSelector.tsx
@@ -343,8 +343,7 @@ export function CabinSelector({
     const desc = (accommodation.description || '') + ' ' + (accommodation.additional_info || '');
     const lowerDesc = desc.toLowerCase();
     
-    // Simple rule: if it contains just 'bath' (not preceded by other words like 'shared'), it's private
-    // If it contains 'shared bath', 'communal bath', etc., it's shared
+    // Rule: 'shared bath' = shared, 'private bath' = private, just 'bath' = private, nothing = shared
     if (lowerDesc.includes('shared bath') || 
         lowerDesc.includes('communal bath') || 
         lowerDesc.includes('shared facilities') ||
@@ -352,21 +351,19 @@ export function CabinSelector({
       return 'shared';
     }
     
-    // If it just mentions 'bath' or 'bathroom' (including 'private bath'), it's private
+    if (lowerDesc.includes('private bath') || 
+        lowerDesc.includes('private bathroom') ||
+        lowerDesc.includes('ensuite') || 
+        lowerDesc.includes('en-suite')) {
+      return 'private';
+    }
+    
+    // If it just says 'bath' or 'bathroom' (without shared/private qualifiers), it's private
     if (lowerDesc.includes('bath')) {
       return 'private';
     }
     
-    // Default based on accommodation type patterns
-    const title = accommodation.title.toLowerCase();
-    if (title.includes('micro cabin') || title.includes('attic') || title.includes('dovecote')) {
-      return 'private';
-    }
-    if (title.includes('dorm') || title.includes('bell tent') || title.includes('tipi') || title.includes('own tent') || title.includes('van')) {
-      return 'shared';
-    }
-    
-    // Default fallback
+    // If no bathroom mention at all, default to shared
     return 'shared';
   };
 


### PR DESCRIPTION
## Summary
• Complete bathroom filter fix with correct logic for all cases
• 'shared bath' descriptions → shared bathroom filter
• 'private bath' descriptions → private bathroom filter  
• just 'bath' descriptions → private bathroom filter
• no bathroom mention → shared bathroom filter (default)

## Previous Context
PR #21 was merged but only included partial fixes. This PR includes the complete solution that handles all bathroom description scenarios correctly.

## Test plan
- [ ] Test 'shared bath' descriptions appear only in shared bathroom filter
- [ ] Test 'private bath' descriptions appear only in private bathroom filter
- [ ] Test descriptions with just 'bath' appear only in private bathroom filter  
- [ ] Test accommodations with no bathroom mention appear only in shared bathroom filter

🤖 Generated with [Claude Code](https://claude.ai/code)