### PR TITLE
Add decompression pricing display to landing page

### DIFF
--- a/src/components/AnimatedTerminal.tsx
+++ b/src/components/AnimatedTerminal.tsx
@@ -404,6 +404,22 @@ export function AnimatedTerminal({ onComplete }: Props) {
             </motion.div>
           )}
         </AnimatePresence>
+        
+        {/* Decompression pricing at the very bottom */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 2, duration: 1 }}
+          className="absolute bottom-4 left-1/2 transform -translate-x-1/2 text-center"
+          style={{ color: 'var(--castle-text-accent)', fontFamily: 'var(--castle-font-primary)' }}
+        >
+          <div className="space-y-1 text-xs sm:text-sm">
+            <div>GARDEN DECOMPRESSION €125</div>
+            <div>WEEKEND DECOMPRESSION €400</div>
+            <div>FULL DECOMPRESSION €275</div>
+            <div>OCTOBER WEEK €275</div>
+          </div>
+        </motion.div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add decompression pricing section to the bottom of the landing page
- Display 4 pricing options with clear pricing: Garden Decompression (€125), Weekend Decompression (€400), Full Decompression (€275), and October Week (€275)
- Position pricing at bottom of page with smooth fade-in animation using consistent castle theme styling

## Test plan
- [ ] Verify pricing section appears at the bottom of the landing page
- [ ] Confirm fade-in animation works properly with 2-second delay
- [ ] Test responsive design on different screen sizes (text should scale from xs to sm)
- [ ] Validate styling matches castle theme variables for color and font
- [ ] Check that pricing information is clearly readable and properly centered

🤖 Generated with [Claude Code](https://claude.ai/code)