### PR TITLE
Fix NaN total issue and add BTC/ETH payment display

### DIFF
--- a/src/components/BookingSummary.tsx
+++ b/src/components/BookingSummary.tsx
@@ -479,7 +479,7 @@ export function BookingSummary({
           // NEW: Store accommodation price after seasonal/duration but before discount codes
           accommodationPriceAfterSeasonalDuration: parseFloat(accommodationAfterSeasonalDuration.toFixed(2)),
           // NEW: Store subtotal after discount code but before credits
-          subtotalAfterDiscountCode: parseFloat(subtotalAfterDiscountCode.toFixed(2)),
+          subtotalAfterDiscountCode: parseFloat(pricing.totalAmount.toFixed(2)),
           // FIXED: Store exact discount code amount for payment breakdown
           discountCodeAmount: parseFloat(exactDiscountCodeAmount.toFixed(2)),
           paymentRowId: paymentRowIdToUse,
@@ -1350,23 +1350,18 @@ Please manually create the booking for this user or process a refund.`;
               <div className="bg-transparent"> {/* Removed mt-6 */}
                 {/* Total Donated - Shows value being donated to the garden */}
                 <div className="pt-4 mt-4">
+                  {/* Total */}
                   <div className="flex font-mono justify-between items-baseline">
                     <span className="uppercase text-primary font-display text-2xl">Total</span>
-                    {/* Show original price if discount applied */}
-                    {false ? (
-                        <div className="text-right">
-                            <span className="text-sm line-through text-secondary mr-2">
-                                {formatPriceDisplay(pricing.subtotal)}
-                            </span>
-                            <span className="text-2xl font-display text-primary">
-                                {formatPriceDisplay(pricing.totalAmount)}
-                            </span>
-                        </div>
-                    ) : (
-                        <span className="text-2xl font-display text-primary">
-                            {formatPriceDisplay(pricing.totalAmount)}
-                        </span>
-                    )}
+                    <div className="text-right">
+                      <span className="text-2xl font-display text-primary">
+                        {formatPriceDisplay(pricing.totalAmount)}
+                      </span>
+                      {/* BTC/ETH info right under the total */}
+                      <div className="text-xs text-secondary mt-1">
+                        BTC & ETH accepted
+                      </div>
+                    </div>
                   </div>
                 </div>
 

--- a/src/components/BookingSummary/BookingSummary.hooks.ts
+++ b/src/components/BookingSummary/BookingSummary.hooks.ts
@@ -29,12 +29,12 @@ export function usePricing({
     const displayWeeks = selectedWeeks.length > 0 ? Math.round(exactWeeksDecimal * 10) / 10 : 0;
     
     // === Calculate Accommodation Cost using discounted weekly price ===
-    // Ensure we have a valid number, default to 0 if null/undefined/NaN
+    // Use base price from selectedAccommodation if calculatedWeeklyAccommodationPrice is not available
     const weeklyAccPrice = (calculatedWeeklyAccommodationPrice !== null && 
                            calculatedWeeklyAccommodationPrice !== undefined && 
                            !isNaN(calculatedWeeklyAccommodationPrice)) 
                           ? calculatedWeeklyAccommodationPrice 
-                          : 0;
+                          : (selectedAccommodation?.base_price || 0);
     const totalAccommodationCost = parseFloat((weeklyAccPrice * displayWeeks).toFixed(2));
 
     // === Calculate Food & Facilities Cost ===
@@ -56,12 +56,6 @@ export function usePricing({
     let finalTotalAmount = subtotal;
     let discountCodeAmount = 0;
 
-    // --- START: Calculate VAT (24%) ---
-    const vatRate = 0.24; // 24% VAT
-    const vatAmount = parseFloat((finalTotalAmount * vatRate).toFixed(2));
-    const totalWithVat = parseFloat((finalTotalAmount + vatAmount).toFixed(2));
-    // --- END: Calculate VAT ---
-
     // 5. Construct the final object
     const calculatedPricingDetails: PricingDetails = {
       totalNights,
@@ -78,8 +72,8 @@ export function usePricing({
       durationDiscountAmount: foodDiscountAmount,
       durationDiscountPercent: rawDurationDiscountPercent * 100,
       seasonalDiscount: 0, // This is calculated elsewhere in the parent component
-      vatAmount,
-      totalWithVat,
+      vatAmount: 0, // No VAT for nonprofit donations
+      totalWithVat: finalTotalAmount, // Same as totalAmount since no VAT
     };
 
 
@@ -89,9 +83,9 @@ export function usePricing({
       calculatedPricingDetails.subtotal = calculatedPricingDetails.totalAccommodationCost; // Keep accom cost, just zero out food
       calculatedPricingDetails.totalAmount = calculatedPricingDetails.totalAccommodationCost; // Total is just accom cost
       calculatedPricingDetails.durationDiscountAmount = 0; // No food discount applicable
-      // Recalculate VAT for test accommodation
-      calculatedPricingDetails.vatAmount = parseFloat((calculatedPricingDetails.totalAmount * vatRate).toFixed(2));
-      calculatedPricingDetails.totalWithVat = parseFloat((calculatedPricingDetails.totalAmount + calculatedPricingDetails.vatAmount).toFixed(2));
+      // No VAT for nonprofit
+      calculatedPricingDetails.vatAmount = 0;
+      calculatedPricingDetails.totalWithVat = calculatedPricingDetails.totalAmount;
     }
     // --- END TEST ACCOMMODATION OVERRIDE ---
 


### PR DESCRIPTION
## Summary
- Fixed NaN error that appeared when selecting accommodation
- Added prominent BTC & ETH payment option display under total
- Removed VAT calculations since this is a nonprofit donation

## Changes
- Updated  hook to use accommodation base_price as fallback when calculatedWeeklyAccommodationPrice is null
- Added 'BTC & ETH accepted' text directly under the total amount for better visibility
- Removed VAT (24%) calculations and display from pricing logic
- Simplified total display to clearly show donation amount

## Test Plan
- [ ] Select different accommodations and verify total displays correctly (no NaN)
- [ ] Verify BTC & ETH payment option is visible under total
- [ ] Confirm VAT is no longer shown in price breakdown
- [ ] Test with various date ranges to ensure pricing calculations work

🤖 Generated with [Claude Code](https://claude.ai/code)