### PR TITLE
Fix NaN issue - Remove food costs, accommodation only

### DIFF
--- a/src/components/BookingSummary/BookingSummary.hooks.ts
+++ b/src/components/BookingSummary/BookingSummary.hooks.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { getSeasonalDiscount, getDurationDiscount, getSeasonBreakdown } from '../../utils/pricing';
 import { calculateTotalNights, calculateDurationDiscountWeeks, calculateTotalWeeksDecimal } from '../../utils/dates';
-import { calculateBaseFoodCost } from './BookingSummary.utils';
 import type { Week } from '../../types/calendar';
 import type { Accommodation } from '../../types';
 import type { PricingDetails, GardenAddon } from './BookingSummary.types';
@@ -37,20 +36,15 @@ export function usePricing({
                           : (selectedAccommodation?.base_price || 0);
     const totalAccommodationCost = parseFloat((weeklyAccPrice * displayWeeks).toFixed(2));
 
-    // === Calculate Food & Facilities Cost ===
-    const baseFoodCost = calculateBaseFoodCost(totalNights);
+    // No food cost - accommodation only
+    const finalFoodCost = 0;
+    const foodDiscountAmount = 0;
+    const rawDurationDiscountPercent = 0;
+    const effectiveWeeklyRate = 0;
     
-    // Apply duration discount to food if staying 3+ weeks
-    const rawDurationDiscountPercent = getDurationDiscount(completeWeeks);
-    const foodDiscountAmount = parseFloat((baseFoodCost * rawDurationDiscountPercent).toFixed(2));
-    const finalFoodCost = parseFloat((baseFoodCost - foodDiscountAmount).toFixed(2));
-    
-    // Calculate effective weekly rate for display
-    const effectiveWeeklyRate = displayWeeks > 0 ? +(finalFoodCost / displayWeeks).toFixed(2) : 0;
-    
-    // 4. Subtotal includes accommodation, food, and garden addon
+    // Subtotal includes accommodation and garden addon only
     const gardenAddonCost = gardenAddon?.price || 0;
-    const subtotal = totalAccommodationCost + finalFoodCost + gardenAddonCost;
+    const subtotal = totalAccommodationCost + gardenAddonCost;
 
     // No discount codes - simplified pricing
     let finalTotalAmount = subtotal;


### PR DESCRIPTION
## Summary
- Fixed NaN error preventing bookings from completing
- Removed all food & facilities cost calculations
- Simplified pricing to accommodation-only model
- Removed Food & Facilities section from price breakdown modal

## Changes
- Set all food-related costs to 0 in pricing calculations
- Removed calculateBaseFoodCost import and usage
- Updated PriceBreakdownModal to show only accommodation costs
- Fixed payment creation that was failing due to NaN amount

## Testing
- Build passes successfully
- Booking flow should now complete without NaN errors