### PR TITLE
Update: 6 days text & crypto payment with room details

### DIFF
--- a/src/components/BookingSummary.tsx
+++ b/src/components/BookingSummary.tsx
@@ -1271,7 +1271,7 @@ Please manually create the booking for this user or process a refund.`;
                     ? testPaymentAmount // Otherwise use admin test amount if set
                     : finalAmountAfterCredits // Use amount after credits
                 }
-                description={`${selectedAccommodation?.title || (gardenAddon ? `Garden Decompression: ${gardenAddon.name}` : 'Booking')} for ${pricing.totalNights} nights${selectedCheckInDate ? ` from ${formatInTimeZone(selectedCheckInDate, 'UTC', 'd. MMMM')}` : ''}`}
+                description={`${selectedAccommodation?.title || (gardenAddon ? `Garden Decompression: ${gardenAddon.name}` : 'Booking')} for 6 days${selectedCheckInDate ? ` from ${formatInTimeZone(selectedCheckInDate, 'UTC', 'd. MMMM')}` : ''}`}
                 bookingMetadata={(selectedAccommodation || gardenAddon) && selectedCheckInDate ? {
                   accommodationId: selectedAccommodation?.id || null,
                   checkIn: selectedCheckInDate ? formatInTimeZone(selectedCheckInDate, 'UTC', 'yyyy-MM-dd') : undefined,

--- a/src/components/StripeCheckoutForm.tsx
+++ b/src/components/StripeCheckoutForm.tsx
@@ -37,6 +37,22 @@ interface Props {
 }
 
 export function StripeCheckoutForm({ total, authToken, description, userEmail, onSuccess, onClose, bookingMetadata, paymentRowId }: Props) {
+  // Create dynamic mailto URL with room information
+  const createCryptoMailtoUrl = () => {
+    const subject = encodeURIComponent("Bitcoin/Ethereum Payment Request");
+    const body = encodeURIComponent(`Hi,
+
+I'd like to pay with cryptocurrency for my booking:
+
+${description}
+Total: €${total}
+
+Please provide Bitcoin or Ethereum payment details.
+
+Thank you!`);
+    
+    return `mailto:concierge@castle.community?subject=${subject}&body=${body}`;
+  };
   useEffect(() => {
     console.log('[StripeCheckout] Current environment:', import.meta.env.MODE);
   }, []);
@@ -255,7 +271,7 @@ export function StripeCheckoutForm({ total, authToken, description, userEmail, o
             textAlign: 'center'
           }}>
             <a 
-              href="mailto:concierge@castle.community?subject=Bitcoin%2FEthereum%20Payment%20Inquiry&body=Hi%2C%0A%0AI%27d%20like%20to%20pay%20with%20cryptocurrency%20for%20my%20booking.%20Please%20provide%20payment%20details.%0A%0AThank%20you"
+              href={createCryptoMailtoUrl()}
               style={{
                 color: '#666',
                 fontSize: '13px',


### PR DESCRIPTION
- Change 'for X nights' to 'for 6 days' in booking description
- Enhance BTC & ETH mailto to include specific room and total price  
- Dynamic email body with booking details for crypto payments