### PR TITLE
Add crypto mailto links and fix payment modal z-index

### DIFF
--- a/src/components/BookingSummary.tsx
+++ b/src/components/BookingSummary.tsx
@@ -1359,7 +1359,12 @@ Please manually create the booking for this user or process a refund.`;
                       </span>
                       {/* BTC/ETH info right under the total */}
                       <div className="text-xs text-secondary mt-1">
-                        BTC & ETH accepted
+                        <a 
+                          href="mailto:concierge@castle.community?subject=I%20want%20to%20secure%20a%20room%20with%20crypto"
+                          className="hover:text-primary transition-colors"
+                        >
+                          BTC & ETH accepted
+                        </a>
                       </div>
                     </div>
                   </div>
@@ -1397,7 +1402,12 @@ Please manually create the booking for this user or process a refund.`;
                   <div className="mt-6 p-4 bg-surface/30 rounded-sm border border-border/50">
                     <div className="text-center">
                       <p className="text-xs text-secondary mb-2 font-mono">
-                        BTC & ETH also accepted
+                        <a 
+                          href="mailto:concierge@castle.community?subject=I%20want%20to%20secure%20a%20room%20with%20crypto"
+                          className="hover:text-primary transition-colors"
+                        >
+                          BTC & ETH also accepted
+                        </a>
                       </p>
                       <p className="text-xs text-secondary font-mono">
                         Contact: <a 

--- a/src/components/StripeCheckoutForm.tsx
+++ b/src/components/StripeCheckoutForm.tsx
@@ -39,7 +39,7 @@ interface Props {
 export function StripeCheckoutForm({ total, authToken, description, userEmail, onSuccess, onClose, bookingMetadata, paymentRowId }: Props) {
   // Create dynamic mailto URL with room information
   const createCryptoMailtoUrl = () => {
-    const subject = encodeURIComponent("Bitcoin/Ethereum Payment Request");
+    const subject = encodeURIComponent("I want to secure a room with crypto");
     const body = encodeURIComponent(`Hi,
 
 I'd like to pay with cryptocurrency for my booking:
@@ -191,7 +191,32 @@ Thank you!`);
   }, [authToken, clientSecret, onSuccess, onClose, paymentRowId]);
 
   if (!clientSecret) {
-    return <div>Loading checkout...</div>;
+    return createPortal(
+      <div 
+        style={{ 
+          position: 'fixed',
+          top: '0',
+          left: '0',
+          width: '100%',
+          height: '100%',
+          backgroundColor: 'rgba(0, 0, 0, 0.75)',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          zIndex: 2147483647, // Maximum z-index value
+          isolation: 'isolate'
+        }}
+      >
+        <div style={{
+          color: 'white',
+          fontSize: '18px',
+          fontWeight: '500'
+        }}>
+          Loading payment...
+        </div>
+      </div>,
+      document.body
+    );
   }
 
   console.log('[StripeCheckout] Rendering as portal outside normal component hierarchy');
@@ -208,7 +233,7 @@ Thank you!`);
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
-        zIndex: 999999,
+        zIndex: 2147483647, // Maximum z-index value
         isolation: 'isolate'
       }}
     >


### PR DESCRIPTION
## Summary
- Made 'BTC & ETH accepted' text clickable with mailto links to concierge@castle.community
- Updated email subject to 'I want to secure a room with crypto'
- Fixed payment loading modal z-index to ensure it's always on top (using max z-index: 2147483647)

## Changes
1. **BookingSummary.tsx**: Wrapped both 'BTC & ETH accepted' instances in anchor tags with mailto link
2. **StripeCheckoutForm.tsx**: 
   - Updated createCryptoMailtoUrl() function to use new subject line
   - Fixed loading state to render as proper fullscreen modal using portal
   - Increased all z-index values to maximum (2147483647) to ensure modals are always on top

## Test plan
- [ ] Click on 'BTC & ETH accepted' text - should open email client with correct subject
- [ ] Open payment modal - loading state should appear as fullscreen overlay
- [ ] Verify payment modal appears above all other elements on the page

🤖 Generated with Claude Code