### PR TITLE
Make crypto payment links visually obvious

### DIFF
--- a/src/components/BookingSummary.tsx
+++ b/src/components/BookingSummary.tsx
@@ -1361,9 +1361,9 @@ Please manually create the booking for this user or process a refund.`;
                       <div className="text-xs text-secondary mt-1">
                         <a 
                           href="mailto:concierge@castle.community?subject=I%20want%20to%20secure%20a%20room%20with%20crypto"
-                          className="hover:text-primary transition-colors"
+                          className="underline hover:text-primary transition-colors cursor-pointer"
                         >
-                          BTC & ETH accepted
+                          BTC & ETH accepted →
                         </a>
                       </div>
                     </div>
@@ -1404,9 +1404,9 @@ Please manually create the booking for this user or process a refund.`;
                       <p className="text-xs text-secondary mb-2 font-mono">
                         <a 
                           href="mailto:concierge@castle.community?subject=I%20want%20to%20secure%20a%20room%20with%20crypto"
-                          className="hover:text-primary transition-colors"
+                          className="underline hover:text-primary transition-colors cursor-pointer"
                         >
-                          BTC & ETH also accepted
+                          BTC & ETH also accepted →
                         </a>
                       </p>
                       <p className="text-xs text-secondary font-mono">

--- a/src/components/StripeCheckoutForm.tsx
+++ b/src/components/StripeCheckoutForm.tsx
@@ -300,11 +300,18 @@ Thank you!`);
               style={{
                 color: '#666',
                 fontSize: '13px',
-                textDecoration: 'none',
-                transition: 'color 0.2s'
+                textDecoration: 'underline',
+                transition: 'color 0.2s',
+                cursor: 'pointer'
               }}
-              onMouseEnter={(e) => e.currentTarget.style.color = '#000'}
-              onMouseLeave={(e) => e.currentTarget.style.color = '#666'}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.color = '#000';
+                e.currentTarget.style.textDecoration = 'underline';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.color = '#666';
+                e.currentTarget.style.textDecoration = 'underline';
+              }}
             >
               BTC &amp; ETH accepted →
             </a>


### PR DESCRIPTION
## Summary
The previous PR #40 was merged but the second commit with visual improvements was not included. This PR adds those missing changes:

- Adds underline to all 'BTC & ETH accepted' text
- Adds arrow (→) indicator 
- Adds cursor pointer on hover
- Maintains consistent hover effects

## Changes
- Updated BookingSummary.tsx: Added underline and arrow to both crypto link instances
- Updated StripeCheckoutForm.tsx: Added underline styling and maintained hover effects

## Testing
- Click any 'BTC & ETH accepted' link - should open email with correct subject
- Links should be clearly visible as clickable (underlined with arrow)
- Hover should show pointer cursor

🤖 Generated with Claude Code