### PR TITLE
Remove blur effect from sold out items

### DIFF
--- a/src/components/CabinSelector.tsx
+++ b/src/components/CabinSelector.tsx
@@ -729,7 +729,7 @@ export function CabinSelector({
                             !tentAcc.sold_out && "hover:bg-surface-hover",
                             selectedAccommodationId === tentAcc.id && "bg-[color-mix(in_srgb,_var(--color-bg-surface)_95%,_var(--color-accent-primary)_5%)] shadow-lg",
                             // Enhanced sold out styling
-                            tentAcc.sold_out && "opacity-90 cursor-not-allowed grayscale-[0.5] pointer-events-none",
+                            tentAcc.sold_out && "opacity-100 cursor-not-allowed pointer-events-none",
                             // Regular disabled state
                             !tentAcc.sold_out && (!testMode && (!selectedWeeks.length || isDisabled)) && "opacity-50 cursor-not-allowed"
                           )}
@@ -758,7 +758,7 @@ export function CabinSelector({
                             !vanAcc.sold_out && "hover:bg-surface-hover",
                             selectedAccommodationId === vanAcc.id && "bg-[color-mix(in_srgb,_var(--color-bg-surface)_95%,_var(--color-accent-primary)_5%)] shadow-lg",
                             // Enhanced sold out styling
-                            vanAcc.sold_out && "opacity-90 cursor-not-allowed grayscale-[0.5] pointer-events-none",
+                            vanAcc.sold_out && "opacity-100 cursor-not-allowed pointer-events-none",
                             // Regular disabled state
                             !vanAcc.sold_out && (!testMode && (!selectedWeeks.length || isDisabled)) && "opacity-50 cursor-not-allowed"
                           )}
@@ -846,7 +846,7 @@ export function CabinSelector({
                       ? "shadow-lg bg-[color-mix(in_srgb,_var(--color-bg-surface)_95%,_var(--color-accent-primary)_5%)]" 
                       : "bg-surface", // Use the renamed class
                     // Sold out state - enhanced styling
-                    acc.sold_out && "opacity-90 grayscale-[0.5]",
+                    acc.sold_out && "opacity-100",
                     // Pointer state:
                     (testMode || (finalCanSelect && !isDisabled)) && !acc.sold_out && 'cursor-pointer',
                     // Disable hover effects for sold out items
@@ -930,9 +930,9 @@ export function CabinSelector({
                     <div className={clsx(
                       "relative h-56 overflow-hidden", // REMOVED bg-surface
                       // Apply blur and corresponding opacity/grayscale conditionally
-                      !testMode && isDisabled && "blur-sm opacity-20 grayscale-[0.5]",
-                      !testMode && (!isDisabled && isFullyBooked) && "blur-sm opacity-20 grayscale-[0.7]",
-                      !testMode && (!isDisabled && isOutOfSeason && !isFullyBooked) && "blur-sm opacity-40 grayscale-[0.3]"
+                      !testMode && isDisabled && "opacity-50 grayscale-[0.5]",
+                      !testMode && (!isDisabled && isFullyBooked) && "opacity-50 grayscale-[0.7]",
+                      !testMode && (!isDisabled && isOutOfSeason && !isFullyBooked) && "opacity-60 grayscale-[0.3]"
                     )}>
                       <ImageGallery accommodation={acc} />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent pointer-events-none"></div> {/* Increased gradient opacity from 40% to 60% */}


### PR DESCRIPTION
## Summary
- Removed all blur effects that were making text fuzzy and unreadable
- Set sold out items to 100% opacity for full visibility
- Removed grayscale effects from sold out items
- Improved readability for all disabled/booked states

## Changes
- Removed blur-sm from all accommodation state classes
- Updated opacity values for better text visibility

🤖 Generated with [Claude Code](https://claude.ai/code)