### PR TITLE
Fix undefined checkIn/checkOut error in MyBookings

### DIFF
--- a/src/components/MyBookings.tsx
+++ b/src/components/MyBookings.tsx
@@ -185,6 +185,8 @@ export function MyBookings() {
   const [enlargedImageUrl, setEnlargedImageUrl] = React.useState<string | null>(null);
   const [enlargedAccommodation, setEnlargedAccommodation] = React.useState<ExtendedAccommodation | null>(null);
   const [originalCheckOut, setOriginalCheckOut] = React.useState<Date | null>(null);
+  const [extendingBooking, setExtendingBooking] = React.useState<Booking | null>(null);
+  const [extensionWeeks, setExtensionWeeks] = React.useState<any[]>([]);
   
   // Masonry gallery state
   const [galleryOpen, setGalleryOpen] = React.useState(false);
@@ -216,6 +218,19 @@ export function MyBookings() {
 
   // Credits functionality for extensions - allows users to use their available credits
   // to reduce the amount they need to pay for their booking extension
+
+  // Derive checkIn and checkOut from the extending booking if available
+  const checkIn = extendingBooking 
+    ? (typeof extendingBooking.check_in === 'string' 
+        ? normalizeToUTCDate(extendingBooking.check_in) 
+        : extendingBooking.check_in)
+    : new Date();
+    
+  const checkOut = extendingBooking
+    ? (typeof extendingBooking.check_out === 'string' 
+        ? normalizeToUTCDate(extendingBooking.check_out) 
+        : extendingBooking.check_out)
+    : addMonths(new Date(), 1);
 
   const calendar = useCalendar({
     startDate: checkIn,


### PR DESCRIPTION
## Summary
- Fixed ReferenceError that was preventing the MyBookings page from loading
- Added missing state declarations that were causing undefined variable errors
- Ensured bookings display properly after creation

## Changes
- Added `extendingBooking` and `extensionWeeks` state declarations
- Fixed `checkIn` and `checkOut` variables to properly derive from `extendingBooking` state with fallback values
- This resolves the console error: `ReferenceError: checkIn is not defined`

## Test plan
- [x] Build completes without errors
- [x] MyBookings page loads without console errors
- [x] Bookings are fetched and displayed correctly
- [x] Extension functionality works with proper state management

🤖 Generated with [Claude Code](https://claude.ai/code)