### PR TITLE
Center 'Pick your nest' heading

### DIFF
--- a/src/pages/Book2Page.tsx
+++ b/src/pages/Book2Page.tsx
@@ -852,7 +852,7 @@ export function Book2Page() {
               {/* Outer Cabin Selector keeps py-* padding */}
               <div className="rounded-sm shadow-sm py-3 xs:py-4 sm:py-6 mb-4 xs:mb-5 sm:mb-6 cabin-selector">
                 {/* REMOVING px-* padding from this h2 */}
-                <h2 className="text-2xl sm:text-3xl  font-display font-light text-primary mb-3 xs:mb-4">Pick your nest</h2>
+                <h2 className="text-2xl sm:text-3xl font-display font-light text-primary mb-3 xs:mb-4 text-center">Pick your nest</h2>
                 <CabinSelector 
                   accommodations={accommodations || []}
                   selectedAccommodationId={selectedAccommodation}


### PR DESCRIPTION
## Summary
Centers the 'Pick your nest' heading on the booking page for better visual alignment.

## Change
- Added `text-center` class to the h2 element

## Screenshot
The heading is now properly centered above the accommodation selector.

## Test Plan
- [x] Verified heading displays centered on desktop
- [x] Verified heading displays centered on mobile
- [x] No other visual elements affected

🤖 Generated with [Claude Code](https://claude.ai/code)