### PR TITLE
URGENT: Fix DIY Tent/Van check-in/out times

### DIFF
--- a/src/components/AccommodationInfoModal.tsx
+++ b/src/components/AccommodationInfoModal.tsx
@@ -80,23 +80,23 @@ const getCheckInOutInfo = (title: string, propertyLocation?: string | null) => {
     };
   }
   
-  // Your Own Van - 5PM CHECK-IN
-  if (lowerTitle.includes('own van') || lowerTitle.includes('van parking') || lowerTitle.includes('your own van')) {
+  // Your Own Van / DIY Van - 5PM CHECK-IN
+  if (lowerTitle.includes('own van') || lowerTitle.includes('van parking') || lowerTitle.includes('your own van') || lowerTitle.includes('diy van')) {
     return {
       checkIn: '5pm on 21st',
       checkOut: '3pm on 26th',
       notes: 'Valley Gardens location. Located in secure compound with 24-hour security, 2 min walk from Chateau.',
-      type: 'Your Own Van'
+      type: lowerTitle.includes('diy') ? 'DIY Van' : 'Your Own Van'
     };
   }
   
-  // Your Own Tent - 5PM CHECK-IN
-  if (lowerTitle.includes('own tent') || lowerTitle.includes('your own tent')) {
+  // Your Own Tent / DIY Tent - 5PM CHECK-IN
+  if (lowerTitle.includes('own tent') || lowerTitle.includes('your own tent') || lowerTitle.includes('diy tent')) {
     return {
       checkIn: '5pm on 21st',
       checkOut: '3pm on 26th',
       notes: 'Valley Gardens location. Located in secure compound with 24-hour security, 2 min walk from Chateau.',
-      type: 'Your Own Tent'
+      type: lowerTitle.includes('diy') ? 'DIY Tent' : 'Your Own Tent'
     };
   }
   

--- a/src/components/CabinSelector.tsx
+++ b/src/components/CabinSelector.tsx
@@ -462,8 +462,8 @@ export function CabinSelector({
         if (title.includes('single tipi')) return 1;
         
         // Priority 2: DIY camping (Own tent/van)
-        if (title.includes('own tent') || title.includes('your own tent')) return 2;
-        if (title.includes('own van') || title.includes('van parking') || title.includes('your own van')) return 3;
+        if (title.includes('own tent') || title.includes('your own tent') || title.includes('diy tent')) return 2;
+        if (title.includes('own van') || title.includes('van parking') || title.includes('your own van') || title.includes('diy van')) return 3;
         
         // Priority 3: Le Dorm (budget option)
         if (title === 'le dorm') return 4;


### PR DESCRIPTION
## Critical Fix Required

The previous PR (#59) missed an important issue: **DIY Tent** and **DIY Van** accommodations were not being recognized and were falling back to default times.

## The Problem
- "DIY Tent [Gardens]" was showing: **4pm check-in, 11:30am check-out** (WRONG)
- Should be: **5pm check-in, 3pm check-out** with Valley Gardens location

## The Root Cause
The code was checking for "own tent" and "your own tent" but NOT "diy tent".
Similarly for "diy van".

## The Fix
Updated both `AccommodationInfoModal.tsx` and `CabinSelector.tsx` to recognize:
- "diy tent" → 5pm check-in, 3pm check-out, Valley Gardens location
- "diy van" → 5pm check-in, 3pm check-out, Valley Gardens location

## Changes Made
1. Added "diy tent" condition to tent check-in/out logic
2. Added "diy van" condition to van check-in/out logic
3. Updated ordering to properly handle DIY Tent/Van titles
4. Display correct type name ("DIY Tent" vs "Your Own Tent")

## Testing
Please verify that:
- DIY Tent shows 5pm check-in, 3pm check-out
- DIY Van shows 5pm check-in, 3pm check-out
- Both show "Valley Gardens location" in notes
- Both appear at top of accommodation list

This needs to be deployed ASAP as users are currently seeing incorrect check-in/check-out times.

🤖 Generated with [Claude Code](https://claude.ai/code)