### PR TITLE
Update map width and change 'sold out' to 'booked out'

### DIFF
--- a/src/components/CabinSelector.tsx
+++ b/src/components/CabinSelector.tsx
@@ -741,7 +741,7 @@ export function CabinSelector({
                         >
                           <h3 className="text-lg font-medium text-primary font-lettra-bold uppercase mb-2">YOUR OWN TENT</h3>
                           {tentAcc.sold_out ? (
-                            <span className="text-red-600 text-xl font-bold font-mono tracking-wider">SOLD OUT</span>
+                            <span className="text-white text-xl font-bold font-mono tracking-wider">BOOKED OUT</span>
                           ) : (
                             <span className="text-accent-primary text-xl font-lettra-bold font-mono">Free</span>
                           )}
@@ -770,7 +770,7 @@ export function CabinSelector({
                         >
                           <h3 className="text-lg font-medium text-primary font-lettra-bold uppercase mb-2">YOUR OWN VAN</h3>
                           {vanAcc.sold_out ? (
-                            <span className="text-red-600 text-xl font-bold font-mono tracking-wider">SOLD OUT</span>
+                            <span className="text-white text-xl font-bold font-mono tracking-wider">BOOKED OUT</span>
                           ) : (
                             <span className="text-accent-primary text-xl font-lettra-bold font-mono">Free</span>
                           )}
@@ -882,7 +882,7 @@ export function CabinSelector({
                 >
                   {/* Use the StatusOverlay helper component */}
                   <StatusOverlay isVisible={acc.sold_out} zIndex={5}>
-                    <span className="text-red-600 font-bold text-lg tracking-wider">SOLD OUT</span>
+                    <span className="text-white font-bold text-lg tracking-wider">BOOKED OUT</span>
                   </StatusOverlay>
                   <StatusOverlay isVisible={!testMode && isDisabled && !acc.sold_out} zIndex={4}>
                     Select dates first

--- a/src/components/admin/Accommodations.tsx
+++ b/src/components/admin/Accommodations.tsx
@@ -1413,7 +1413,7 @@ export function Accommodations() {
                       disabled={createLoading} 
                       className={checkboxInputClassName}
                     />
-                    <span className="font-semibold">Sold Out</span>
+                    <span className="font-semibold">Booked Out</span>
                   </label>
                 </div>
               </div>
@@ -1769,7 +1769,7 @@ export function Accommodations() {
                          </label>
                          <label className={`${checkboxLabelClassName} text-orange-500`}>
                             <input type="checkbox" checked={!!currentEditData.sold_out} onChange={(e) => handleInputChange(e, 'sold_out')} disabled={editLoading} className={checkboxInputClassName}/>
-                            <span className="font-semibold">Sold Out</span>
+                            <span className="font-semibold">Booked Out</span>
                          </label>
                     </div>
                   </>
@@ -1824,7 +1824,7 @@ export function Accommodations() {
                     <div className="flex gap-2 pt-1 flex-wrap"> 
                       {accommodation.has_wifi && <span className="inline-flex items-center gap-1 bg-[var(--color-bg-success-subtle)] text-[var(--color-text-success)] px-2 py-0.5 rounded-sm text-xs"><Wifi size={12}/> WiFi</span>}
                       {accommodation.has_electricity && <span className="inline-flex items-center gap-1 bg-[var(--color-bg-success-subtle)] text-[var(--color-text-success)] px-2 py-0.5 rounded-sm text-xs"><Zap size={12}/> Electricity</span>}
-                      {accommodation.sold_out && <span className="inline-flex items-center gap-1 bg-orange-100 text-orange-700 px-2 py-0.5 rounded-sm text-xs font-semibold">SOLD OUT</span>}
+                      {accommodation.sold_out && <span className="inline-flex items-center gap-1 bg-gray-100 text-gray-700 px-2 py-0.5 rounded-sm text-xs font-semibold">BOOKED OUT</span>}
                       {!accommodation.has_wifi && !accommodation.has_electricity && !accommodation.sold_out && <span className='text-xs italic'>No listed features.</span>}
                     </div>
                   </>

--- a/src/pages/Book2Page.tsx
+++ b/src/pages/Book2Page.tsx
@@ -854,7 +854,7 @@ export function Book2Page() {
                 <img 
                   src="/images/castle-map.jpg" 
                   alt="Castle Map" 
-                  className="w-full max-w-3xl rounded-sm"
+                  className="w-full max-w-5xl rounded-sm"
                 />
               </div>
               


### PR DESCRIPTION
## Summary
- Made castle map image wider for better visibility
- Changed all "sold out" text to "booked out" with white styling for a softer, less aggressive appearance

## Changes
1. **Castle Map Width**
   - Increased width from `max-w-3xl` to `max-w-5xl` 
   - Map now displays larger above "Pick your nest" section

2. **Booking Status Text Updates**
   - Changed all "SOLD OUT" text to "BOOKED OUT"
   - Updated text color from red (`text-red-600`) to white (`text-white`)
   - Applies to:
     - Main accommodation cards
     - Your Own Tent/Van buttons
     - Admin panel labels and badges

3. **Admin Panel Styling**
   - Updated badge color from orange to gray for consistency
   - Changed label text to match new "Booked Out" terminology

## Visual Impact
- Less aggressive messaging with white text instead of red
- Consistent "booked out" terminology throughout the app
- Larger, more visible castle map for better user orientation

## Test Plan
- [x] Build completes successfully
- [x] "BOOKED OUT" displays in white on accommodation cards
- [x] Castle map displays wider above accommodation selection
- [x] Admin panel shows updated terminology and styling

🤖 Generated with [Claude Code](https://claude.ai/code)