### PR TITLE
Remove default sort button and set low-to-high as default

### DIFF
--- a/src/components/CabinSelector.tsx
+++ b/src/components/CabinSelector.tsx
@@ -172,7 +172,7 @@ export function CabinSelector({
   const [showOnlySharedBathrooms, setShowOnlySharedBathrooms] = useState(false);
   
   // State for price sorting - default to cheapest first
-  const [sortBy, setSortBy] = useState<'default' | 'price-low' | 'price-high'>('price-low');
+  const [sortBy, setSortBy] = useState<'price-low' | 'price-high'>('price-low');
   
   // State for simple gallery
   const [galleryOpen, setGalleryOpen] = useState(false);
@@ -622,19 +622,6 @@ export function CabinSelector({
         <div className="flex items-center gap-2">
           <span className="text-sm text-secondary font-mono">Sort by:</span>
           <div className="flex items-center gap-2">
-            <button
-              onClick={() => setSortBy('default')}
-              className={clsx(
-                "flex items-center gap-2 px-4 py-2 rounded-sm border transition-all duration-200 font-mono text-sm",
-                sortBy === 'default'
-                  ? "bg-accent-primary text-white border-accent-primary"
-                  : "bg-surface text-secondary border-border hover:border-accent-primary"
-              )}
-            >
-              <ArrowUpDown size={16} />
-              <span>Default</span>
-            </button>
-            
             <button
               onClick={() => setSortBy('price-low')}
               className={clsx(


### PR DESCRIPTION
## Summary
Simplified the sorting interface by removing the 'Default' button and making 'Price: Low to High' the default sort option.

## Changes
- **Removed 'Default' sort button** - Cleaner interface with fewer options
- **Set 'Price: Low to High' as default** - Accommodations now load sorted by lowest price first
- **Updated TypeScript types** - sortBy state now only accepts 'price-low' or 'price-high'

## User Impact
- Simpler, cleaner sorting interface
- Budget-friendly options appear first by default
- Users can still toggle between low-to-high and high-to-low sorting

## Test Plan
- [x] Build completes successfully
- [x] Accommodations load sorted by price (low to high) by default
- [x] Sort buttons work correctly
- [x] No 'Default' button appears in the UI

🤖 Generated with [Claude Code](https://claude.ai/code)