### PR TITLE
Add 'Post-Castle Decompression @ Bottom' text

### DIFF
--- a/src/pages/Book2Page.tsx
+++ b/src/pages/Book2Page.tsx
@@ -866,6 +866,11 @@ export function Book2Page() {
                       Pick your nest
                     </h2>
                   </div>
+                  <div className="flex flex-wrap items-center justify-center">
+                    <p className="text-base sm:text-lg font-display font-light text-secondary text-center">
+                      Post-Castle Decompression @ Bottom
+                    </p>
+                  </div>
                 </div>
                 <CabinSelector 
                   accommodations={accommodations || []}


### PR DESCRIPTION
## Summary
Added subtitle text "Post-Castle Decompression @ Bottom" below the "Pick your nest" heading to provide context about the post-event decompression option.

## Changes
- Added new text element below "Pick your nest" heading
- Styled with secondary color for visual hierarchy
- Responsive text sizing (base on mobile, lg on desktop)
- Uses font-display for consistency with other headings

## Visual Impact
- Provides additional context about accommodation options
- Maintains visual hierarchy with secondary color
- Clean integration with existing layout

## Test Plan
- [x] Build completes successfully
- [x] Text appears correctly below "Pick your nest"
- [x] Responsive sizing works on mobile and desktop
- [x] Visual hierarchy maintained with proper styling

🤖 Generated with [Claude Code](https://claude.ai/code)