### PR TITLE
Fix checkout modal centering on desktop

### DIFF
--- a/src/components/AccommodationInfoModal.tsx
+++ b/src/components/AccommodationInfoModal.tsx
@@ -129,7 +129,7 @@ export function AccommodationInfoModal({ isOpen, onClose, title, propertyLocatio
             initial={{ opacity: 0, scale: 0.95, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
-            className="fixed inset-4 md:inset-auto md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 z-[101] md:w-[90%] md:max-w-md max-h-[calc(100vh-2rem)] md:max-h-[90vh] overflow-y-auto"
+            className="fixed inset-4 md:inset-auto md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 z-[101] md:max-w-md max-h-[calc(100vh-2rem)] md:max-h-[90vh] overflow-y-auto"
           >
             <div className="bg-surface border border-border rounded-sm shadow-2xl h-full md:h-auto flex flex-col">
               {/* Header */}


### PR DESCRIPTION
## Summary
- Fixed modal centering issue that made OK button inaccessible on desktop
- Removed conflicting width property that caused modal to extend beyond viewport
- Modal now properly centers with appropriate max-width constraints

## Problem
Users had to switch to mobile view to click the OK button on the accommodation info modal during checkout, as it was cut off on desktop screens.

## Solution
Removed the `md:w-[90%]` class that was conflicting with the centering logic, keeping only `md:max-w-md` for proper responsive behavior.

## Test plan
- [x] Modal displays correctly on desktop with OK button visible
- [x] Modal still works on mobile (full-screen display)
- [x] Centering is maintained across all viewport sizes

🤖 Generated with [Claude Code](https://claude.ai/code)