### PR TITLE
2026 booking gate: patron early access, entitlement sync, July 19 on-sale

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Deploy Functions
         run: |
           supabase functions deploy stripe-payment-webhook --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
-          supabase functions deploy create-booking-securely --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
           supabase functions deploy validate-discount-code --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+          supabase functions deploy rooms-sync --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+          supabase functions deploy check-user-access --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }} 

--- a/netlify.toml
+++ b/netlify.toml
@@ -41,4 +41,4 @@
     Access-Control-Allow-Methods = "*"
     Access-Control-Allow-Headers = "*"
     Content-Security-Policy = "default-src 'self'; connect-src 'self' https://*.stripe.com https://api.stripe.com https://js.stripe.com https://*.supabase.co wss://*.supabase.co; script-src 'self' https://js.stripe.com https://m.stripe.network https://hcaptcha.com https://*.hcaptcha.com 'unsafe-inline'; worker-src 'self' blob:; frame-src 'self' https://js.stripe.com https://payments.stripe.com https://hcaptcha.com https://*.hcaptcha.com; img-src 'self' data: https: https://*.stripe.com; style-src 'self' 'unsafe-inline' https://js.stripe.com https://fonts.googleapis.com; font-src 'self' https://js.stripe.com https://fonts.gstatic.com;"
-    Permissions-Policy = "payment=(self 'https://js.stripe.com'), fullscreen=(self)"
+    Permissions-Policy = 'payment=(self "https://js.stripe.com"), fullscreen=(self)'

--- a/src/components/AnimatedTerminal.tsx
+++ b/src/components/AnimatedTerminal.tsx
@@ -29,6 +29,23 @@ const MOBILE_ASCII_ART = `████████╗██╗  ██╗██�
 ╚██████╔╝██║  ██║██║  ██║██████╔╝███████╗██║ ╚████║
  ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝ ╚══════╝╚═╝  ╚═══╝`;
 
+// Prefill the login email from ?email= — the ticket-site rooms handoff falls
+// back to this page with the buyer's address when auto sign-in fails.
+function getPrefilledEmail(): string {
+  try {
+    const raw = new URLSearchParams(window.location.search).get('email') ?? '';
+    let value = raw;
+    try {
+      value = decodeURIComponent(raw);
+    } catch {
+      // Already decoded — use as-is
+    }
+    return value.trim();
+  } catch {
+    return '';
+  }
+}
+
 export function AnimatedTerminal({ onComplete }: Props) {
   const [asciiLines, setAsciiLines] = useState<string[]>([]);
   const [currentLine, setCurrentLine] = useState(0);
@@ -38,7 +55,8 @@ export function AnimatedTerminal({ onComplete }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [showLogin, setShowLogin] = useState(false);
-  const [email, setEmail] = useState('');
+  const [prefilledEmail] = useState(() => getPrefilledEmail());
+  const [email, setEmail] = useState(prefilledEmail);
   const [otp, setOtp] = useState('');
   const [otpSent, setOtpSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -126,27 +144,29 @@ export function AnimatedTerminal({ onComplete }: Props) {
     try {
       console.log('[AnimatedTerminal] Requesting code for:', normalizedEmail);
       
-      // STEP 1: Check if user is in whitelist (includes both active and pending)
-      console.log('[AnimatedTerminal] Checking whitelist status...');
-      const { data: whitelistData, error: whitelistError } = await supabase
-        .from('whitelist_all')
-        .select('email, status')
-        .eq('email', normalizedEmail)
-        .single();
+      // STEP 1: Check access via the check-user-access edge function
+      // (service role inside — anon can no longer read the guest list directly)
+      console.log('[AnimatedTerminal] Checking access...');
+      const { data: accessData, error: accessError } = await supabase.functions.invoke('check-user-access', {
+        body: { email: normalizedEmail }
+      });
 
-      if (whitelistError || !whitelistData) {
-        console.log('[AnimatedTerminal] User not in whitelist:', normalizedEmail);
-        throw new Error('Access denied. Please contact an administrator to be added to the whitelist.');
+      if (accessError || !accessData?.canAccess) {
+        console.log('[AnimatedTerminal] Access denied for:', normalizedEmail);
+        throw new Error(
+          prefilledEmail
+            ? 'Access denied. Email concierge@castle.community to get sorted.'
+            : 'Access denied. Please contact an administrator to be added to the whitelist.'
+        );
       }
 
-      console.log('[AnimatedTerminal] User is whitelisted (status:', whitelistData.status, '), sending OTP...');
+      console.log('[AnimatedTerminal] Access granted, sending OTP...');
 
       // STEP 2: Send OTP code for ALL whitelisted users
-      // Don't use shouldCreateUser - let Supabase handle it based on whether user exists
-      const { error } = await supabase.auth.signInWithOtp({ 
+      const { error } = await supabase.auth.signInWithOtp({
         email: normalizedEmail,
         options: {
-          // Don't specify shouldCreateUser - let Supabase decide
+          shouldCreateUser: false, // Accounts are provisioned by rooms-sync/admin — never on login
           emailRedirectTo: undefined // No redirect, just OTP code
         }
       });

--- a/src/components/AnimatedTerminal.tsx
+++ b/src/components/AnimatedTerminal.tsx
@@ -235,7 +235,7 @@ export function AnimatedTerminal({ onComplete }: Props) {
     <div 
       className="h-[100dvh] bg-cover bg-center bg-no-repeat flex items-center justify-center"
       style={{
-        backgroundImage: `url('https://guquxpxxycfmmlqajdyw.supabase.co/storage/v1/object/public/accommodations/castle-main.jpg')`
+        backgroundImage: `url('/images/castle-map.jpg')`
       }}
     >
       <div className="w-full h-full max-w-[1000px] relative flex items-center justify-center px-4" ref={containerRef}>
@@ -428,4 +428,3 @@ export function AnimatedTerminal({ onComplete }: Props) {
     </div>
   );
 }
-

--- a/src/components/BookingSummary.tsx
+++ b/src/components/BookingSummary.tsx
@@ -34,6 +34,12 @@ import { ConfirmButtons } from './BookingSummary/components/ConfirmButtons';
 // Import utils
 import { formatPriceDisplay } from './BookingSummary/BookingSummary.utils';
 
+// 2026 booking-open gate: the bookings table trigger raises BOOKING_NOT_OPEN
+// before booking_opens_at for non-patrons — surface it as friendly copy.
+const BOOKING_NOT_OPEN_MESSAGE = "Booking isn't open yet — rooms open for booking on July 19.";
+const isBookingNotOpenError = (err: unknown): boolean =>
+  String((err as { message?: unknown } | null)?.message ?? err ?? '').includes('BOOKING_NOT_OPEN');
+
 export function BookingSummary({
   selectedWeeks,
   selectedAccommodation,
@@ -42,7 +48,8 @@ export function BookingSummary({
   seasonBreakdown: initialSeasonBreakdown,
   calculatedWeeklyAccommodationPrice,
   gardenAddon,
-  onClearGardenAddon
+  onClearGardenAddon,
+  bookingLocked = false
 }: BookingSummaryProps) {
   // --- REMOVED: Track component renders (no longer needed) ---
   // Helper function to format dates consistently (needed for the modal)
@@ -973,7 +980,7 @@ Please manually create the booking for this user or process a refund.`;
         err
       });
       // Don't re-throw any errors - we've handled them gracefully above
-      setErrorWithLogging('An error occurred. Please try again.');
+      setErrorWithLogging(isBookingNotOpenError(err) ? BOOKING_NOT_OPEN_MESSAGE : 'An error occurred. Please try again.');
       setIsBookingWithLogging(false);
     }
   }, [selectedAccommodation, selectedWeeks, selectedCheckInDate, navigate, pricing.totalAmount, creditsToUse, refreshCreditsWithLogging, userEmail, onClearWeeks, onClearAccommodation, bookingService, finalAmountAfterCredits]);
@@ -1131,6 +1138,13 @@ Please manually create the booking for this user or process a refund.`;
             
           } catch (bookingErr) {
             console.error('[BOOKING_FLOW] STEP 3.5 WARNING: Could not create pending booking:', bookingErr);
+            // 2026 booking-open gate: stop here instead of proceeding to payment
+            if (isBookingNotOpenError(bookingErr)) {
+              console.warn('[BOOKING_FLOW] STEP 3.5 BLOCKED: booking gate is closed (BOOKING_NOT_OPEN)');
+              setErrorWithLogging(BOOKING_NOT_OPEN_MESSAGE);
+              setIsBookingWithLogging(false);
+              return;
+            }
             // Check if this is the no_new_pending_bookings constraint
             if (bookingErr && typeof bookingErr === 'object' && 'code' in bookingErr && bookingErr.code === '23514') {
               console.log('[BOOKING_FLOW] Database constraint preventing pending bookings - will create booking after payment');
@@ -1175,7 +1189,7 @@ Please manually create the booking for this user or process a refund.`;
       setShowStripeModalWithLogging(true);
     } catch (err) {
       console.error('[BOOKING_FLOW] Error in handleConfirmClick:', err);
-      setErrorWithLogging('An error occurred. Please try again.');
+      setErrorWithLogging(isBookingNotOpenError(err) ? BOOKING_NOT_OPEN_MESSAGE : 'An error occurred. Please try again.');
       setIsBookingWithLogging(false); // Reset booking flag on error
       
       // Clean up any pending booking if it was created
@@ -1429,6 +1443,7 @@ Please manually create the booking for this user or process a refund.`;
                   creditsToUse={creditsToUse}
                   isAdmin={isAdmin}
                   permissionsLoading={permissionsLoading}
+                  bookingLocked={bookingLocked}
                   onConfirm={handleConfirmClick}
                   onAdminConfirm={handleAdminConfirm}
                 />

--- a/src/components/BookingSummary.tsx
+++ b/src/components/BookingSummary.tsx
@@ -28,7 +28,8 @@ import { usePricing } from './BookingSummary/BookingSummary.hooks';
 import { StayDetails } from './BookingSummary/components/StayDetails';
 import { AccommodationSection } from './BookingSummary/components/AccommodationSection';
 import { GardenAddonSection } from './BookingSummary/components/GardenAddonSection';
-import { CreditsSection } from './BookingSummary/components/CreditsSection';
+// CreditsSection retired for 2026 — credits are zeroed and the column is locked
+// (see 20260610_booking_open_gate.sql); import kept out so the UI can't resurface.
 import { ConfirmButtons } from './BookingSummary/components/ConfirmButtons';
 
 // Import utils
@@ -98,7 +99,7 @@ export function BookingSummary({
 
   // --- State for Credits ---
   const [creditsToUse, setCreditsToUse] = useState<number>(0);
-  const [creditsEnabled, setCreditsEnabled] = useState<boolean>(true); // Default to using credits
+  const [creditsEnabled] = useState<boolean>(false); // Credits retired for 2026 — keep off so the auto-apply effect never deducts them
   const { credits: availableCredits, loading: creditsLoading, refresh: refreshCredits } = useCredits();
   
   // --- ADDED: Track if user has manually adjusted credits ---
@@ -127,12 +128,8 @@ export function BookingSummary({
     setCreditsToUse(value);
   }, []);
   
-  // --- Manual credit adjustment function ---
-  const setCreditsToUseManually = useCallback((value: number) => {
-    setCreditsToUse(value);
-    setUserHasManuallyAdjustedCredits(true);
-  }, []);
-  
+  // --- Manual credit adjustment was only reachable through CreditsSection — retired for 2026 ---
+
   // Track refreshCredits calls
   const refreshCreditsWithLogging = useCallback(async () => {
     try {
@@ -1420,18 +1417,7 @@ Please manually create the booking for this user or process a refund.`;
                   </div>
                 </div>
 
-                {/* Credits Section */}
-                                  <CreditsSection
-                    availableCredits={availableCredits}
-                    creditsLoading={creditsLoading}
-                    creditsEnabled={creditsEnabled}
-                    setCreditsEnabled={setCreditsEnabled}
-                    creditsToUse={creditsToUse}
-                    setCreditsToUse={setCreditsToUseManually}
-                    pricing={pricing}
-                    finalAmountAfterCredits={finalAmountAfterCredits}
-                  />
-
+                {/* Credits Section — retired for 2026 (credits zeroed + column locked; rooms are paid in full) */}
 
                 {/* Confirm Buttons */}
                 <ConfirmButtons

--- a/src/components/BookingSummary/BookingSummary.types.ts
+++ b/src/components/BookingSummary/BookingSummary.types.ts
@@ -29,6 +29,7 @@ export interface BookingSummaryProps {
   calculatedWeeklyAccommodationPrice: number | null;
   gardenAddon?: GardenAddon | null;
   onClearGardenAddon?: () => void;
+  bookingLocked?: boolean; // 2026 booking-open gate: browse mode until booking_opens_at
 }
 
 // Helper function to calculate pricing details

--- a/src/components/BookingSummary/components/ConfirmButtons.tsx
+++ b/src/components/BookingSummary/components/ConfirmButtons.tsx
@@ -9,6 +9,7 @@ interface ConfirmButtonsProps {
   creditsToUse: number;
   isAdmin: boolean;
   permissionsLoading: boolean;
+  bookingLocked?: boolean; // 2026 booking-open gate: browse mode until booking_opens_at
   onConfirm: () => void;
   onAdminConfirm: () => void;
 }
@@ -22,27 +23,28 @@ export function ConfirmButtons({
   creditsToUse,
   isAdmin,
   permissionsLoading,
+  bookingLocked = false,
   onConfirm,
   onAdminConfirm
 }: ConfirmButtonsProps) {
   // Allow booking if either accommodation is selected OR garden addon is selected
   const canProceed = (selectedAccommodation || gardenAddon) && selectedWeeks.length > 0;
-  
+
   return (
     <div className="mt-6 font-mono sm:mt-8">
       <button
         onClick={onConfirm}
-        disabled={isBooking || !canProceed}
+        disabled={isBooking || !canProceed || bookingLocked}
         className={`w-full flex items-center justify-center pixel-corners--wrapper relative overflow-hidden px-6 py-2.5 sm:py-3 text-lg font-medium rounded-sm transition-colors duration-200
           ${
-            isBooking || !canProceed
+            isBooking || !canProceed || bookingLocked
               ? 'bg-transparent text-shade-3 cursor-not-allowed'
               : 'text-stone-800 bg-accent-primary hover:bg-accent-secondary focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring,var(--color-accent-primary))] focus:ring-offset-2 focus:ring-offset-[var(--color-focus-offset,var(--color-bg-main))]'
           }`}
       >
         <span className="pixel-corners--content 2xl:text-2xl">
-          {isBooking ? 'PROCESSING...' : finalAmountAfterCredits === 0 ? 'CONFIRM BOOKING' : 'CONFIRM & DONATE'}
-          
+          {bookingLocked ? 'Booking opens July 19' : isBooking ? 'PROCESSING...' : finalAmountAfterCredits === 0 ? 'CONFIRM BOOKING' : 'CONFIRM & DONATE'}
+
         </span>
       </button>
       

--- a/src/components/MyBookings.tsx
+++ b/src/components/MyBookings.tsx
@@ -26,6 +26,11 @@ import { CreditsSection } from './BookingSummary/components/CreditsSection';
 import { formatPriceDisplay } from './BookingSummary/BookingSummary.utils';
 import { MasonryGallery } from './shared/MasonryGallery';
 
+// Extend Stay is retired for 2026: the booking-open gate locks post-purchase
+// price/date rewrites (the permissive bookings UPDATE policy it relied on was
+// dropped in 20260610_booking_open_gate.sql). UI hidden, service code kept.
+const EXTEND_STAY_ENABLED = false;
+
 // Interface for accommodation images
 interface AccommodationImage {
   id: string;
@@ -1172,7 +1177,8 @@ export function MyBookings() {
         </div>
       )}
 
-      {extendingBooking && createPortal(
+      {/* Extend Stay modal — retired for 2026 (EXTEND_STAY_ENABLED) */}
+      {EXTEND_STAY_ENABLED && extendingBooking && createPortal(
         <AnimatePresence>
           <motion.div
             initial={{ opacity: 0 }}
@@ -1875,8 +1881,8 @@ export function MyBookings() {
         document.body
       )}
 
-      {/* Discount Modal for Extension */}
-      {extendingBooking && extensionOnlyWeeks.length > 0 && (
+      {/* Discount Modal for Extension — retired for 2026 (EXTEND_STAY_ENABLED) */}
+      {EXTEND_STAY_ENABLED && extendingBooking && extensionOnlyWeeks.length > 0 && (
         <DiscountModal
           isOpen={showDiscountModal}
           onClose={() => setShowDiscountModal(false)}

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -44,11 +44,11 @@ export function useCalendar({ startDate, endDate, isAdminMode = false }: UseCale
 
     // Generate weeks with customizations
     const weeks = useMemo(() => {
-        // HARDCODED FOR CASTLE BOOKING: Single week Sept 21-26, 2025
+        // HARDCODED FOR CASTLE BOOKING: Single week Aug 2-7, 2026
         const singleWeek: Week = {
-            id: 'sept-21-26-2025',
-            startDate: new Date('2025-09-21T00:00:00Z'),
-            endDate: new Date('2025-09-26T00:00:00Z'),
+            id: 'aug-2-7-2026',
+            startDate: new Date('2026-08-02T00:00:00Z'),
+            endDate: new Date('2026-08-07T00:00:00Z'),
             name: 'The Castle',
             status: 'available' as WeekStatus,
             isCustom: true,
@@ -68,10 +68,10 @@ export function useCalendar({ startDate, endDate, isAdminMode = false }: UseCale
                 isAdminMode
             );
             // Add our single week at the beginning if it's not already there
-            const hasSeptWeek = generatedWeeks.some(w => 
+            const hasCastleWeek = generatedWeeks.some(w =>
                 w.startDate.getTime() === singleWeek.startDate.getTime()
             );
-            if (!hasSeptWeek) {
+            if (!hasCastleWeek) {
                 return [singleWeek, ...generatedWeeks];
             }
             return generatedWeeks;

--- a/src/pages/Book2Page.tsx
+++ b/src/pages/Book2Page.tsx
@@ -101,9 +101,9 @@ export function Book2Page() {
   
   // Initialize with pre-selected The Castle week
   const [selectedWeeks, setSelectedWeeks] = useState<Week[]>([{
-    id: 'castle-week-sept-2025',
-    startDate: new Date('2025-09-21T00:00:00Z'),
-    endDate: new Date('2025-09-26T00:00:00Z'),
+    id: 'castle-week-aug-2026',
+    startDate: new Date('2026-08-02T00:00:00Z'),
+    endDate: new Date('2026-08-07T00:00:00Z'),
     name: 'The Castle',
     status: 'available' as WeekStatus,
     isCustom: false,
@@ -254,9 +254,9 @@ export function Book2Page() {
 
   // HARDCODED SINGLE WEEK - No calendar hook needed
   const castleWeek: Week = {
-    id: 'castle-week-sept-2025',
-    startDate: new Date('2025-09-21T00:00:00Z'),
-    endDate: new Date('2025-09-26T00:00:00Z'), // End date at midnight (start of 26th)
+    id: 'castle-week-aug-2026',
+    startDate: new Date('2026-08-02T00:00:00Z'),
+    endDate: new Date('2026-08-07T00:00:00Z'), // End date at midnight (start of the 7th)
     name: 'The Castle',
     status: 'available' as WeekStatus,
     isCustom: false,
@@ -891,7 +891,7 @@ export function Book2Page() {
                   <div className="flex flex-wrap items-center justify-center gap-3">
                     {/* Increased font size for the header */}
                     <h2 className="text-2xl sm:text-3xl font-display font-light text-primary text-center">
-                      The Castle · September 21-26, 2025
+                      The Castle · August 2-7, 2026
                     </h2>
                   </div>
 
@@ -948,7 +948,7 @@ export function Book2Page() {
               
               {/* Garden Decompression Addon - MOVED AFTER accommodations */}
               <GardenDecompressionAddon
-                castleEndDate={new Date('2025-09-26T00:00:00Z')}
+                castleEndDate={new Date('2026-08-07T00:00:00Z')}
                 onSelectAddon={setSelectedGardenAddon}
                 selectedAddon={selectedGardenAddon}
               />

--- a/src/pages/Book2Page.tsx
+++ b/src/pages/Book2Page.tsx
@@ -25,6 +25,7 @@ import { areSameWeeks } from '../utils/dates';
 import { clsx } from 'clsx';
 import { calculateDaysBetween } from '../utils/dates';
 import { bookingService } from '../services/BookingService';
+import { supabase } from '../lib/supabase';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { InfoBox } from '../components/InfoBox';
 import { useUserPermissions } from '../hooks/useUserPermissions';
@@ -186,10 +187,63 @@ export function Book2Page() {
   const combinedDiscount = calculateCombinedDiscount(selectedWeeks);
 
   const { session, isLoading: sessionLoading } = useSession();
-  
+
   const { isAdmin, isLoading: permissionsLoading } = useUserPermissions(session);
-  
+
   const isMobile = window.innerWidth < 768;
+
+  // --- 2026 booking-open gate: browse mode until booking_opens_at (patrons/admins exempt) ---
+  const [bookingOpensAt, setBookingOpensAt] = useState<Date | null>(null);
+  const [bookingTier, setBookingTier] = useState<string | null>(null);
+  const [bookingGateLoaded, setBookingGateLoaded] = useState(false);
+
+  useEffect(() => {
+    if (sessionLoading) return;
+    const userId = session?.user?.id;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const [settingsResult, profileResult] = await Promise.all([
+          supabase.from('settings').select('value').eq('key', 'booking_opens_at').maybeSingle(),
+          userId
+            ? supabase.from('profiles').select('booking_tier').eq('id', userId).maybeSingle()
+            : Promise.resolve({ data: null }),
+        ]);
+        if (cancelled) return;
+        const opensAtValue = (settingsResult.data as { value?: string } | null)?.value;
+        const parsedOpensAt = opensAtValue ? new Date(opensAtValue) : null;
+        setBookingOpensAt(parsedOpensAt && !isNaN(parsedOpensAt.getTime()) ? parsedOpensAt : null);
+        setBookingTier((profileResult.data as { booking_tier?: string | null } | null)?.booking_tier ?? null);
+      } catch (error) {
+        console.error('[Book2Page] Error loading booking gate state:', error);
+        // Leave defaults (no opens-at, no tier) — locked for non-patrons, fail closed
+      } finally {
+        if (!cancelled) setBookingGateLoaded(true);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [session?.user?.id, sessionLoading]);
+
+  const bookingLocked = useMemo(() => {
+    if (!bookingGateLoaded) return false; // Don't flash the lock while loading
+    if (isAdmin || bookingTier === 'PATRON') return false;
+    if (!bookingOpensAt) return true; // Missing settings row = locked for non-patrons
+    return Date.now() < bookingOpensAt.getTime();
+  }, [bookingGateLoaded, isAdmin, bookingTier, bookingOpensAt]);
+
+  const daysUntilOpen = useMemo(() => {
+    if (!bookingOpensAt) return null;
+    return Math.max(0, Math.ceil((bookingOpensAt.getTime() - Date.now()) / 86400000));
+  }, [bookingOpensAt]);
+
+  const bookingCountdownLabel = daysUntilOpen === null
+    ? 'ROOMS OPEN JULY 19'
+    : daysUntilOpen === 0
+      ? 'ROOMS OPEN TODAY'
+      : `ROOMS OPEN IN ${daysUntilOpen} ${daysUntilOpen === 1 ? 'DAY' : 'DAYS'}`;
+  // --- END: 2026 booking-open gate ---
 
   // --- START: Normalize date specifically for the calendar hook ---
   const calendarStartDate = startOfMonthUTC(currentMonth);
@@ -708,7 +762,16 @@ export function Book2Page() {
       )}
       
       <div className="container mx-auto py-4 xs:py-6 sm:py-8 px-4">
-        
+
+        {/* 2026 booking-open gate: browse freely, booking unlocks July 19 (patrons are in already) */}
+        {bookingLocked && (
+          <div className="bg-amber-900/20 border border-amber-700/30 rounded-sm p-3 mb-4">
+            <p className="text-sm text-amber-200 font-mono text-center">
+              {bookingCountdownLabel} · July 19 — patrons are choosing now
+            </p>
+          </div>
+        )}
+
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 xs:gap-5 sm:gap-6">
           {/* Left Column - Calendar and Cabin Selector */}
           <div className="lg:col-span-2">
@@ -908,6 +971,7 @@ export function Book2Page() {
                     calculatedWeeklyAccommodationPrice={selectedAccommodation ? (weeklyAccommodationInfo[selectedAccommodation]?.price ?? selectedAccommodationObject?.base_price ?? 0) : null}
                     gardenAddon={selectedGardenAddon}
                     onClearGardenAddon={() => setSelectedGardenAddon(null)}
+                    bookingLocked={bookingLocked}
                   />
                 ) : (
                   <div className="text-secondary text-sm xs:text-sm font-mono">

--- a/src/services/BookingService.ts
+++ b/src/services/BookingService.ts
@@ -32,16 +32,18 @@ class BookingService {
       const result = await supabase
         .from('accommodations')
         .select('*')
+        .eq('archived', false) // glamping retired for 2026
         .order('display_order', { ascending: true });
-      
+
       if (result.error) {
         console.error('[BookingService] Error fetching accommodations:', result.error);
         console.log('[BookingService] Attempting fallback query without ordering...');
-        
+
         // Fallback: try without ordering
         const fallbackResult = await supabase
           .from('accommodations')
-          .select('*');
+          .select('*')
+          .eq('archived', false);
           
         if (fallbackResult.error) {
           console.error('[BookingService] Fallback query also failed:', fallbackResult.error);

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,6 +2,10 @@
 [functions.stripe-webhook]
 verify_jwt = false
 
+# rooms-sync authenticates with a shared secret (X-Sync-Secret), not a Supabase JWT.
+[functions.rooms-sync]
+verify_jwt = false
+
 [api]
 port = 54321
 schemas = ["public", "storage", "graphql_public"]

--- a/supabase/functions/check-user-access/index.ts
+++ b/supabase/functions/check-user-access/index.ts
@@ -46,16 +46,14 @@ serve(async (req) => {
     // Check if user exists in profiles table (by email)
     const { data: profileData, error: profileError } = await supabaseAdmin
       .from('profiles')
-      .select('id, email, is_admin')
+      .select('id')
       .eq('email', normalizedEmail)
       .single()
 
     if (profileError || !profileData) {
       console.log(`User ${normalizedEmail} not in whitelist`)
-      return new Response(JSON.stringify({ 
-        message: 'Access denied. Please contact an administrator to be added to the whitelist.',
-        canAccess: false,
-        reason: 'not_whitelisted'
+      return new Response(JSON.stringify({
+        canAccess: false
       }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         status: 200,
@@ -63,12 +61,10 @@ serve(async (req) => {
     }
 
     // User is in whitelist!
+    // This is an unauthenticated pre-auth probe — return nothing beyond canAccess.
     console.log(`User ${normalizedEmail} is whitelisted`)
-    return new Response(JSON.stringify({ 
-      message: 'Access granted',
-      canAccess: true,
-      userId: profileData.id,
-      isAdmin: profileData.is_admin || false
+    return new Response(JSON.stringify({
+      canAccess: true
     }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       status: 200,
@@ -76,9 +72,8 @@ serve(async (req) => {
 
   } catch (error) {
     console.error('Error:', error)
-    return new Response(JSON.stringify({ 
-      error: error.message || 'Internal server error',
-      canAccess: false 
+    return new Response(JSON.stringify({
+      canAccess: false
     }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       status: 500,

--- a/supabase/functions/rooms-sync/index.ts
+++ b/supabase/functions/rooms-sync/index.ts
@@ -31,7 +31,7 @@ const ADMIN_EMAILS = [
 ]
 
 function getSupabaseAdminClient(): SupabaseClient {
-  const supabaseUrl = Deno.env.get('BACKEND_URL')
+  const supabaseUrl = Deno.env.get('BACKEND_URL') ?? Deno.env.get('SUPABASE_URL')
   const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 
   if (!supabaseUrl || !serviceRoleKey) {

--- a/supabase/functions/rooms-sync/index.ts
+++ b/supabase/functions/rooms-sync/index.ts
@@ -1,0 +1,222 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+
+// Privileged sync endpoint for the ticket site (chatoo). Authenticated with a
+// shared secret header — NOT a Supabase JWT (verify_jwt = false in config.toml).
+//
+// Actions:
+//   sync    — idempotently create the auth user + upsert profiles {email, name,
+//             booking_tier}. Tier never downgrades (PATRON wins). Refuses admins.
+//   handoff — mint a single-use magic link for an already-synced profile so the
+//             ticket site can sign the buyer straight into the rooms app.
+
+interface RequestPayload {
+  action: 'sync' | 'handoff';
+  email: string;
+  name?: string;
+  tier?: string;
+}
+
+// Hardcoded admin list — mirrors public.is_admin()
+// (supabase/migrations/20250806_create_whitelist_tables.sql)
+const ADMIN_EMAILS = [
+  'andre@thegarden.pt',
+  'redis213@gmail.com',
+  'dawn@thegarden.pt',
+  'simone@thegarden.pt',
+  'samjlloa@gmail.com',
+  'living@thegarden.pt',
+  'samckclarke@gmail.com',
+]
+
+function getSupabaseAdminClient(): SupabaseClient {
+  const supabaseUrl = Deno.env.get('BACKEND_URL')
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error('Missing Supabase URL or Service Role Key environment variables.')
+    throw new Error('Server configuration error.')
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}
+
+// Constant-time string comparison so the shared secret can't be timed out byte by byte.
+function constantTimeEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder()
+  const aBytes = encoder.encode(a)
+  const bBytes = encoder.encode(b)
+  if (aBytes.length !== bBytes.length) return false
+  let diff = 0
+  for (let i = 0; i < aBytes.length; i++) {
+    diff |= aBytes[i] ^ bBytes[i]
+  }
+  return diff === 0
+}
+
+function jsonResponse(body: Record<string, unknown>, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    status,
+  })
+}
+
+// Resolve the auth user id for an email that has no profiles row:
+// attempt createUser first (idempotent path for brand-new buyers); if the user
+// is already registered, page through auth.admin.listUsers and match client-side.
+async function resolveAuthUserId(
+  supabaseAdmin: SupabaseClient,
+  email: string,
+): Promise<string | null> {
+  const { data: created, error: createError } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    email_confirm: true,
+  })
+
+  if (!createError && created?.user) {
+    return created.user.id
+  }
+
+  console.log(`createUser failed for ${email} (likely already registered): ${createError?.message}`)
+
+  const perPage = 1000
+  for (let page = 1; page <= 50; page++) {
+    const { data, error } = await supabaseAdmin.auth.admin.listUsers({ page, perPage })
+    if (error) {
+      console.error('listUsers failed:', error)
+      return null
+    }
+    const match = data.users.find((u) => (u.email ?? '').toLowerCase() === email)
+    if (match) return match.id
+    if (data.users.length < perPage) break
+  }
+  return null
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405)
+  }
+
+  try {
+    // --- Shared-secret auth (constant-time) ---
+    const expectedSecret = Deno.env.get('ROOMS_SYNC_SECRET')
+    if (!expectedSecret) {
+      console.error('ROOMS_SYNC_SECRET is not configured.')
+      return jsonResponse({ error: 'Server configuration error' }, 500)
+    }
+    const providedSecret = req.headers.get('X-Sync-Secret') ?? ''
+    if (!constantTimeEqual(providedSecret, expectedSecret)) {
+      return jsonResponse({ error: 'Unauthorized' }, 401)
+    }
+
+    const { action, email, name, tier } = await req.json() as RequestPayload
+
+    if (!email || (action !== 'sync' && action !== 'handoff')) {
+      return jsonResponse({ error: 'Missing email or invalid action' }, 400)
+    }
+
+    const normalizedEmail = email.toLowerCase().trim()
+
+    // Never sync or mint links for admin accounts.
+    if (ADMIN_EMAILS.includes(normalizedEmail)) {
+      return jsonResponse({ error: 'Refused: admin account' }, 400)
+    }
+
+    const supabaseAdmin = getSupabaseAdminClient()
+
+    const { data: existingProfile } = await supabaseAdmin
+      .from('profiles')
+      .select('id, email, is_admin, booking_tier')
+      .eq('email', normalizedEmail)
+      .maybeSingle()
+
+    if (existingProfile?.is_admin) {
+      return jsonResponse({ error: 'Refused: admin account' }, 400)
+    }
+
+    if (action === 'handoff') {
+      if (!existingProfile) {
+        return jsonResponse({ error: 'Profile not found' }, 404)
+      }
+
+      // Redirect target is fixed server-side — never accept a client-supplied redirect.
+      const redirectTo = Deno.env.get('FRONTEND_URL') ?? 'https://rooms.castle.community'
+      const { data: linkData, error: linkError } = await supabaseAdmin.auth.admin.generateLink({
+        type: 'magiclink',
+        email: normalizedEmail,
+        options: { redirectTo },
+      })
+
+      if (linkError || !linkData?.properties?.action_link) {
+        console.error('generateLink failed:', linkError)
+        return jsonResponse({ error: 'Failed to generate login link' }, 500)
+      }
+
+      return jsonResponse({ action_link: linkData.properties.action_link }, 200)
+    }
+
+    // --- action === 'sync' ---
+    let userId = existingProfile?.id ?? null
+    let currentTier: string | null = existingProfile?.booking_tier ?? null
+
+    if (!userId) {
+      userId = await resolveAuthUserId(supabaseAdmin, normalizedEmail)
+      if (!userId) {
+        return jsonResponse({ error: 'Failed to create or locate auth user' }, 500)
+      }
+
+      // A profile row may exist under this id with a stale email — re-check it.
+      const { data: profileById } = await supabaseAdmin
+        .from('profiles')
+        .select('id, is_admin, booking_tier')
+        .eq('id', userId)
+        .maybeSingle()
+
+      if (profileById?.is_admin) {
+        return jsonResponse({ error: 'Refused: admin account' }, 400)
+      }
+      currentTier = profileById?.booking_tier ?? null
+    }
+
+    const profilePayload: Record<string, unknown> = {
+      id: userId,
+      email: normalizedEmail,
+    }
+
+    if (name && name.trim()) {
+      const [firstName, ...rest] = name.trim().split(/\s+/)
+      profilePayload.first_name = firstName
+      profilePayload.last_name = rest.join(' ') || null
+    }
+
+    // Tier never downgrades: once PATRON, always PATRON.
+    if (tier && currentTier !== 'PATRON') {
+      profilePayload.booking_tier = tier
+    }
+
+    const { error: upsertError } = await supabaseAdmin
+      .from('profiles')
+      .upsert(profilePayload, { onConflict: 'id' })
+
+    if (upsertError) {
+      console.error('Profile upsert failed:', upsertError)
+      return jsonResponse({ error: 'Failed to upsert profile' }, 500)
+    }
+
+    console.log(`Synced rooms access for ${normalizedEmail} (tier: ${tier ?? 'unchanged'})`)
+    return jsonResponse({ ok: true, user_id: userId }, 200)
+  } catch (error) {
+    console.error('Error:', error)
+    return jsonResponse({ error: error.message || 'Internal server error' }, 500)
+  }
+})

--- a/supabase/migrations/20260610_booking_open_gate.sql
+++ b/supabase/migrations/20260610_booking_open_gate.sql
@@ -1,0 +1,196 @@
+-- ============================================================================
+-- 2026 booking-open gate: patron early access + July 19 general on-sale
+--
+-- 1. profiles.booking_tier — room entitlement, written only by the rooms-sync
+--    edge function (service role). NULL for the entire 2025 residue.
+-- 2. settings.booking_opens_at — the clock that opens general booking.
+-- 3. Profiles lockdown — users must not self-assign booking_tier / is_admin /
+--    credits (otherwise the gate is decorative).
+-- 4. Booking gate trigger — BEFORE INSERT OR UPDATE on bookings, keyed on the
+--    booking OWNER's profile (NEW.user_id), plus acting-admin override.
+-- 5. Bookings RLS reconciliation — INSERT requires a booking_tier; the
+--    permissive user UPDATE policy (Extend Stay) is dropped, retiring that
+--    flow for 2026.
+-- 6. Anon enumeration off — no more guest-list dumps with the public anon key.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. Entitlement column (NULL for all existing rows — that's the point)
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS booking_tier text;
+
+-- rooms-sync upserts first/last name; ensure the columns exist everywhere.
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS first_name text;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS last_name text;
+
+-- ----------------------------------------------------------------------------
+-- 2. settings table + booking_opens_at seed
+--    (20240321000001_fix_settings_value.sql may already define it with text
+--    value + timestamps; this is compatible.)
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.settings (
+  key text PRIMARY KEY,
+  value text
+);
+
+ALTER TABLE public.settings ENABLE ROW LEVEL SECURITY;
+
+-- Replace the public-read policy: settings are readable by authenticated only.
+DROP POLICY IF EXISTS "Public read access to settings" ON public.settings;
+DROP POLICY IF EXISTS "Authenticated read access to settings" ON public.settings;
+CREATE POLICY "Authenticated read access to settings"
+  ON public.settings FOR SELECT
+  TO authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS "Admin full access to settings" ON public.settings;
+CREATE POLICY "Admin full access to settings"
+  ON public.settings FOR ALL
+  USING (public.is_admin());
+
+REVOKE ALL ON public.settings FROM anon, authenticated;
+GRANT SELECT ON public.settings TO authenticated;
+
+INSERT INTO public.settings (key, value)
+VALUES ('booking_opens_at', '2026-07-19T10:00:00+02:00')
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+
+-- ----------------------------------------------------------------------------
+-- 3. Profiles lockdown
+--    Without this, any user can UPDATE profiles SET booking_tier='PATRON' /
+--    is_admin=true / credits=… on their own row (wide self-update policy +
+--    table-wide grant).
+-- ----------------------------------------------------------------------------
+REVOKE INSERT, UPDATE ON public.profiles FROM authenticated, anon;
+GRANT UPDATE (first_name, last_name) ON public.profiles TO authenticated;
+
+-- Guard trigger: discriminate by DB role, NOT auth.jwt() claims, so SECURITY
+-- DEFINER paths (admin credit RPCs, credit triggers — owned by postgres) keep
+-- working while user-JWT requests cannot touch the protected columns.
+CREATE OR REPLACE FUNCTION public.guard_profiles_protected_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF current_user NOT IN ('service_role', 'postgres', 'supabase_admin') THEN
+    IF NEW.booking_tier IS DISTINCT FROM OLD.booking_tier
+       OR NEW.is_admin IS DISTINCT FROM OLD.is_admin
+       OR NEW.credits IS DISTINCT FROM OLD.credits THEN
+      RAISE EXCEPTION 'PROFILE_PROTECTED_COLUMN';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS guard_profiles_protected_columns ON public.profiles;
+CREATE TRIGGER guard_profiles_protected_columns
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.guard_profiles_protected_columns();
+
+-- ----------------------------------------------------------------------------
+-- 4. Booking gate
+--    Keyed on the booking OWNER (NEW.user_id) — correct under both the
+--    user-JWT direct insert and service-role/RPC paths where auth.uid() is
+--    NULL. SECURITY INVOKER on purpose: current_user must reflect the acting
+--    DB role. Missing settings row ⇒ locked.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.check_booking_open()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  owner_is_admin boolean;
+  owner_tier text;
+  opens_at timestamptz;
+BEGIN
+  SELECT p.is_admin, p.booking_tier
+    INTO owner_is_admin, owner_tier
+    FROM public.profiles p
+   WHERE p.id = NEW.user_id;
+
+  -- Owner-based rules
+  IF COALESCE(owner_is_admin, false) THEN
+    RETURN NEW;
+  END IF;
+
+  IF owner_tier = 'PATRON' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT s.value::timestamptz
+    INTO opens_at
+    FROM public.settings s
+   WHERE s.key = 'booking_opens_at';
+
+  IF owner_tier IS NOT NULL AND opens_at IS NOT NULL AND now() >= opens_at THEN
+    RETURN NEW;
+  END IF;
+
+  -- Acting-user override: admins can create/reassign bookings for anyone.
+  IF auth.uid() IS NOT NULL AND EXISTS (
+    SELECT 1 FROM public.profiles ap WHERE ap.id = auth.uid() AND ap.is_admin
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  -- Service/system roles may UPDATE existing rows (stripe-payment-webhook
+  -- confirms pending bookings via service role). Service-role INSERTs are NOT
+  -- blanket-exempted — they must pass the owner-tier rules above.
+  IF TG_OP = 'UPDATE' AND current_user IN ('service_role', 'postgres', 'supabase_admin') THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'BOOKING_NOT_OPEN';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS booking_open_gate ON public.bookings;
+CREATE TRIGGER booking_open_gate
+  BEFORE INSERT OR UPDATE ON public.bookings
+  FOR EACH ROW
+  EXECUTE FUNCTION public.check_booking_open();
+
+-- ----------------------------------------------------------------------------
+-- 5. Bookings RLS reconciliation
+-- ----------------------------------------------------------------------------
+-- Replace the user INSERT policy: own row + a booking tier required.
+-- (Admin INSERT policy from 20250807_admin_booking_rls.sql stays untouched.)
+DROP POLICY IF EXISTS "Users can create bookings" ON public.bookings;
+DROP POLICY IF EXISTS "Users can insert their own bookings" ON public.bookings;
+CREATE POLICY "Users can create bookings"
+  ON public.bookings FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = auth.uid()
+      AND p.booking_tier IS NOT NULL
+    )
+  );
+
+-- Drop the permissive update-anything policy (20250128000000) that existed
+-- solely for the Extend Stay flow — retired for 2026. The surviving
+-- "Users can update own bookings" policy (20250807) already restricts
+-- non-admin updates to status → 'cancelled'.
+DROP POLICY IF EXISTS "Users can update their own bookings" ON public.bookings;
+
+-- ----------------------------------------------------------------------------
+-- 6. Anon enumeration off
+--    (20250808_fix_whitelist_anon_access.sql granted anon SELECT on the full
+--    guest list; this integration would add the patron flag to that dump.)
+--    Authenticated SELECT grants stay as-is.
+-- ----------------------------------------------------------------------------
+REVOKE SELECT ON public.profiles FROM anon;
+
+DO $$
+BEGIN
+  IF to_regclass('public.whitelist_all') IS NOT NULL THEN
+    REVOKE SELECT ON public.whitelist_all FROM anon;
+  END IF;
+  IF to_regclass('public.whitelist_pending') IS NOT NULL THEN
+    REVOKE SELECT ON public.whitelist_pending FROM anon;
+  END IF;
+END $$;

--- a/supabase/migrations/20260610_booking_open_gate.sql
+++ b/supabase/migrations/20260610_booking_open_gate.sql
@@ -52,7 +52,7 @@ REVOKE ALL ON public.settings FROM anon, authenticated;
 GRANT SELECT ON public.settings TO authenticated;
 
 INSERT INTO public.settings (key, value)
-VALUES ('booking_opens_at', '2026-07-19T10:00:00+02:00')
+VALUES ('booking_opens_at', to_jsonb('2026-07-19T10:00:00+02:00'::text))
 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
 
 -- ----------------------------------------------------------------------------
@@ -119,7 +119,7 @@ BEGIN
     RETURN NEW;
   END IF;
 
-  SELECT s.value::timestamptz
+  SELECT trim(both '"' from s.value::text)::timestamptz
     INTO opens_at
     FROM public.settings s
    WHERE s.key = 'booking_opens_at';

--- a/supabase/migrations/20260611_2026_refresh.sql
+++ b/supabase/migrations/20260611_2026_refresh.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- 2026 content refresh: glamping retired, room pricing, sold_out reset
+--
+-- 1. accommodations.archived — glamping (bell tents + tipis) is retired for
+--    2026 ("expensive and didn't work well"). Archiving instead of deleting
+--    preserves the FK history of 2025 bookings; the guest UI filters it out
+--    (BookingService.getAccommodations).
+-- 2. 2026 pricing — +10% across the board, +20% for the four cheapest castle
+--    rooms (Lierre I, Lierre II, Sahara, Chouette). One-shot: guarded by a
+--    settings marker so re-running this file can never compound prices.
+-- 3. sold_out reset — 2025 sell-outs must not leak into 2026 sales.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. Archive glamping
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.accommodations ADD COLUMN IF NOT EXISTS archived boolean NOT NULL DEFAULT false;
+
+UPDATE public.accommodations SET archived = true
+WHERE id IN (
+  '48e09427-bec3-4659-9754-1998159b5965', -- Single Bed in 3 Person, 4-Meter Bell Tent [Vallery Gardens]
+  'e5b493ec-8dd0-476b-a41c-ba706232bc21', -- Tipi [Vallery Gardens]
+  'e798c3c3-6516-4532-a29a-7f8016d9d494', -- Tipi, Ramparts View (Closest to Chateau)
+  '9378b6fe-cc31-4d94-9eac-857d349076d8', -- 4-Meter Bell Tent [Vallery Gardens]
+  '9e1ea46b-5090-41c7-bc37-797f18724941'  -- 4M Bell Tent, [Castle Grounds / Forest Clearing]
+);
+
+-- ----------------------------------------------------------------------------
+-- 2. 2026 pricing (one-shot, marker-guarded — NEVER compounds on re-run)
+--    +20%: the four cheapest castle rooms. +10%: every other live, priced
+--    accommodation. Archived rows and €0 items (own van / DIY tent) untouched.
+--    All current prices produce whole euros under these multipliers.
+-- ----------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.settings WHERE key = '2026_pricing_applied') THEN
+
+    UPDATE public.accommodations
+       SET base_price = round(base_price * 1.2)
+     WHERE id IN (
+       '01779c04-3c79-49e4-b16b-1a7edae63ec5', -- Lierre I    800 -> 960
+       '939d0715-30df-4620-9bae-4638701fc646', -- Lierre II   800 -> 960
+       'c7fb0610-0787-4aee-a3d8-d1fe2c723a0c', -- Sahara     1700 -> 2040
+       'd836894c-2d5d-4ebc-9262-d16fff8e69a9'  -- Chouette   1700 -> 2040
+     );
+
+    UPDATE public.accommodations
+       SET base_price = round(base_price * 1.1)
+     WHERE id NOT IN (
+       '01779c04-3c79-49e4-b16b-1a7edae63ec5',
+       '939d0715-30df-4620-9bae-4638701fc646',
+       'c7fb0610-0787-4aee-a3d8-d1fe2c723a0c',
+       'd836894c-2d5d-4ebc-9262-d16fff8e69a9'
+     )
+       AND archived = false
+       AND base_price > 0;
+
+    INSERT INTO public.settings (key, value)
+    VALUES ('2026_pricing_applied', now()::text);
+
+  END IF;
+END $$;
+
+-- ----------------------------------------------------------------------------
+-- 3. Reset 2025 sell-out flags for everything still on sale
+-- ----------------------------------------------------------------------------
+UPDATE public.accommodations SET sold_out = false WHERE archived = false;

--- a/supabase/migrations/20260611_2026_refresh.sql
+++ b/supabase/migrations/20260611_2026_refresh.sql
@@ -56,7 +56,7 @@ BEGIN
        AND base_price > 0;
 
     INSERT INTO public.settings (key, value)
-    VALUES ('2026_pricing_applied', now()::text);
+    VALUES ('2026_pricing_applied', to_jsonb(now()::text));
 
   END IF;
 END $$;


### PR DESCRIPTION
Rooms side of the 2026 patron-early-access integration. Spec & audit trail: whatgoodarewords/chatoo#16.

## What this does

- **`rooms-sync` edge function** (shared-secret auth, `verify_jwt=false`): the ticket site pushes paid 2026 buyers into `profiles` with a `booking_tier`, and mints per-click magic-link handoffs. Never downgrades PATRON; refuses admin emails; redirect target fixed server-side.
- **`20260610_booking_open_gate.sql`**:
  - `profiles.booking_tier` — room entitlement; NULL for the entire 2025 residue, so the July 19 clock opens booking only for synced 2026 ticket holders.
  - `settings.booking_opens_at = 2026-07-19T10:00:00+02:00` (authenticated-read).
  - **Profiles lockdown** — closes the pre-existing hole where any user could `UPDATE profiles SET is_admin=true / booking_tier='PATRON' / credits=…` on their own row.
  - **Booking gate trigger** (INSERT + UPDATE, keyed on the booking owner, acting-admin override) raising `BOOKING_NOT_OPEN`.
  - Bookings RLS: INSERT requires an entitlement; permissive Extend-Stay UPDATE policy dropped.
  - Anon guest-list enumeration revoked.
- **Login**: pre-auth check now via `check-user-access` (hardened to return `{canAccess}` only), `shouldCreateUser:false`, `?email=` prefill for the OTP fallback.
- **Browse mode**: countdown banner, locked CTA ("Booking opens July 19"), rooms stay browsable, `BOOKING_NOT_OPEN` surfaced before Stripe.
- **Retired for 2026**: Extend Stay UI + credits section (credits were client-writable — a free-rooms hole at €1200–6000/room).
- CI deploys `rooms-sync` + `check-user-access`; `create-booking-securely` removed from CI (project-side deletion is an ops step).

## Verification

- `npm run build` (vite) passes.
- `tsc` is broken at baseline (corrupted checked-in files); scratch typecheck shows **0 new errors** vs main (141 pre-existing, byte-identical).
- E2E runbook (prod-safe) lives in the spec issue — to be executed after deploy.

## Do not merge before

The ops sequence in chatoo#16: 2026 content refresh + 2025 reset (step 0), then this migration, then edge-function secrets (`ROOMS_SYNC_SECRET`), Supabase auth config (public signups OFF, redirect allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
